### PR TITLE
phone fields may be ambiguous

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -1,6 +1,7 @@
 package publiccode
 
 import (
+	"fmt"
 	"log"
 	"net/url"
 	"regexp"
@@ -412,7 +413,7 @@ func (p *Parser) decodeArrObj(key string, value map[interface{}]interface{}) err
 					}
 					contact.Email = val.(string)
 				} else if k.(string) == "phone" {
-					contact.Phone = val.(string)
+					contact.Phone = fmt.Sprint(val) //forcing cast to string, phone number must always be a string
 				} else if k.(string) == "affiliation" {
 					contact.Affiliation = val.(string)
 				} else {

--- a/parser_test.go
+++ b/parser_test.go
@@ -16,10 +16,12 @@ func TestDecodeValueErrors(t *testing.T) {
 	testFiles := []testType{
 		// A complete and valid yml.
 		{"tests/valid.yml", ""},
-		//A complete and valid minimal yml.
+		// A complete and valid minimal yml.
 		{"tests/valid.minimal.yml", ""},
+		// Fields must be valid against different type
+		{"tests/valid_maintenance_contacts_phone.yml", ""}, // Valid maintenance/contacts/phone.
 
-		//Missing mandatory fields.
+		// Missing mandatory fields.
 		{"tests/missing_publiccodeYmlVersion.yml", "publiccodeYmlVersion"},                       // Missing version.
 		{"tests/missing_name.yml", "name"},                                                       // Missing name.
 		{"tests/missing_legal_license.yml", "legal/license"},                                     // Missing legal/license.

--- a/tests/valid_maintenance_contacts_phone.yml
+++ b/tests/valid_maintenance_contacts_phone.yml
@@ -1,0 +1,186 @@
+publiccodeYmlVersion: "0.2"
+
+name: Medusa
+applicationSuite: MegaProductivitySuite
+url: "https://github.com/italia/developers.italia.it.git"        # URL of this repository
+landingURL: "https://developers.italia.it"
+
+isBasedOn: "https://github.com/italia/developers.italia.it.git"   # The original repository, "Otello"
+softwareVersion: "1.0"                                        # Last stable version
+releaseDate: 2017-04-15                     # Date of last stable software release
+logo: tests/img/logo.png
+monochromeLogo: tests/img/logo-mono.svg
+
+inputTypes:
+  - text/plain
+outputTypes:
+  - text/plain
+
+platforms:                   # or Windows, Mac, Linux, etc.
+  - android
+  - ios
+
+# legacy 0.1 key
+tags:
+  - calendar
+  - chat
+  - classroom-management
+  - museum
+  - music
+  - news
+  - ocr
+  - parallel-computing
+  - revision-control
+  - robotics
+  - scanning
+  - security
+  - sports
+
+categories:
+  - cloud-management
+
+usedBy:
+  - Comune di Firenze
+  - Comune di Roma
+
+roadmap: "https://designers.italia.it/roadmap/"
+
+developmentStatus: development
+
+softwareType: "standalone"
+
+intendedAudience:
+  onlyFor:
+    - cities
+    - health-services
+    - it-ag-agricolo
+  countries:
+    - it
+    - de
+  unsupportedCountries:     # Explicitly unsupported countries
+    - us
+
+description:
+  it:
+    localisedName: Medusa
+    genericName: "Text Editor"
+    shortDescription: "Un software veramente interessante."
+  eng:
+    localisedName: Medusa
+    genericName: "Text Editor"
+    shortDescription: "A really interesting software."
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+
+    documentation: "https://docs.developers.italia.it"
+    apiDocumentation: "https://developers.italia.it/it/api"
+
+    features:
+       - Very important feature
+       - Will run without a problem
+       - Has zero bugs
+       - Solves all the problems of the world
+    screenshots:
+       - tests/img/sshot1.png
+       - tests/img/sshot2.png
+       - tests/img/sshot3.png
+    videos:                             # Demo videos of the software
+       - https://www.youtube.com/watch?v=RaHmGbBOP84
+    awards:
+       - 1st Price Software of the year
+    freeTags:
+      - freeTag
+      - FreeoloTag
+
+legal:
+  license: AGPL-3.0-or-later        # SPDX expression of license
+  mainCopyrightOwner: City of Chicago
+  repoOwner: City of Chicago
+  authorsFile: tests/AUTHORS              # file listing copyright information
+
+maintenance:
+  type: "contract"
+
+  contractors:
+    - name: "Fornitore Privato SPA" # if maintainance is a contract
+      website: "https://developers.italia.it"
+      until: "2019-01-01"
+
+  contacts:
+    - name: Francesco Rossi
+      email: "francesco.rossi@comune.reggioemilia.it"
+      affiliation: Comune di Reggio Emilia
+      phone: 023113215112
+    - name: Dario Bianchi
+      email: "dario.bianchi@fornitore.it"
+      affiliation: Fornitore Privato S.P.A.
+      phone: +391624231322
+    - name: Giancarlo Verdi
+      email: "dario.bianchi@fornitore.it"
+      affiliation: Fornitore Privato S.P.A.
+      phone: '+391624231322'
+
+localisation:
+  # Does the software support, at least by design, multiple languages?
+  localisationReady: yes
+  # Languages already available
+  availableLanguages:
+    - eng
+    - ita
+    - fra
+    - deu
+
+dependsOn:             # List of dependencies. The only mandatory list is the proprietary one
+  open:                 # List of open dependencies. Optional
+    - name: MySQL
+      versionMin: "1.1"
+      versionMax: "1.3"
+      optional: yes
+    - name: PostgreSQL
+      version: "3.2"
+      optional: yes
+  # List of proprietary software which is a dependency for using this product. This includes runtime dependencies
+  proprietary:
+    - name: Oracle
+      versionMin: "11.4"
+    - name: IBM SoftLayer
+  hardware:             # List of special hardware required. Optional.
+    - name: NFC Reader
+      optional: yes
+
+# IT: Italian extension.
+it:
+  conforme:
+    accessibile: yes
+    interoperabile: yes
+    sicuro: yes
+    privacy: yes
+
+  riuso:
+    # Codice IPA della PA che ha pubblicato questo repo (repo-owner)
+    codiceIPA: c_h501
+
+  spid: yes
+  pagopa: yes
+  cie: yes
+  anpr: yes
+  ecosistemi:
+    - scuola
+
+
+  designKit:
+    seo: no
+    ui: yes
+    web: yes
+    content: no

--- a/tests/valid_maintenance_contacts_phone.yml
+++ b/tests/valid_maintenance_contacts_phone.yml
@@ -121,14 +121,17 @@ maintenance:
     - name: Francesco Rossi
       email: "francesco.rossi@comune.reggioemilia.it"
       affiliation: Comune di Reggio Emilia
+      # Test that a phone number with no spaces is parsed correctly despite being potentially parsed as a number instead of a string.
       phone: 023113215112
     - name: Dario Bianchi
       email: "dario.bianchi@fornitore.it"
       affiliation: Fornitore Privato S.P.A.
+      # Test that a phone number with no spaces and a leading + is parsed correctly despite being potentially parsed as a number instead of a string.
       phone: +391624231322
     - name: Giancarlo Verdi
       email: "dario.bianchi@fornitore.it"
       affiliation: Fornitore Privato S.P.A.
+      # Test that a phone number enclosed in quotes is correctly parsed.
       phone: '+391624231322'
 
 localisation:


### PR DESCRIPTION
This PR aim to discuss how to treat phone fields, since they should be a `string` but as for `YAML` standard they could be ambiguous and treated as string/int/float64 in some cases.
Here casting if forced for the maintenance/contact/phone to string to avoid ambiguity.

Additionally: this bug is probably the root cause of many crawling failure during the night.

See here for details:
- https://github.com/nodeca/js-yaml/issues/394
- https://github.com/italia/publiccode-editor/issues/89

@alranel @libremente 