### PR TITLE
pcvalidate cli add version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,9 @@ before:
 builds:
 - 
   main: ./pcvalidate/pcvalidate.go
+  # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
+  ldflags:
+    - -s -w -X main.version={{.Version}} -X main.date={{.Date}}
   env:
   - CGO_ENABLED=0
 archives:

--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ pc := parser.PublicCode
 
 This repository also contains an executable tool which can be used for validating a publiccode.yml file locally.
 
+To get latest development version use:
 ```
 $ go get github.com/italia/publiccode-parser-go/pcvalidate
 $ pcvalidate mypubliccode.yml
 ```
 
+To get latest stable version go to [release page](https://github.com/italia/publiccode-parser-go/releases/latest) and grab which will match your arch.
+
 Run `pcvalidate --help` for the available command line flags.
+
+Run `pcvalidate --version` to print actual version.
 
 The tool returns 0 in case of successful validation, 1 otherwise.
 

--- a/pcvalidate/pcvalidate.go
+++ b/pcvalidate/pcvalidate.go
@@ -11,6 +11,20 @@ import (
 	publiccode "github.com/italia/publiccode-parser-go"
 )
 
+var (
+	version string
+	date    string
+)
+
+func init() {
+	if version == "" {
+		version = "no version"
+	}
+	if date == "" {
+		date = "(Mon YYYY)"
+	}
+}
+
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [ OPTIONS ] publiccode.yml\n", os.Args[0])
@@ -22,7 +36,13 @@ func main() {
 	exportPtr := flag.String("export", "", "Export the normalized publiccode.yml file to the given path.")
 	noStrictPtr := flag.Bool("no-strict", false, "Disable strict mode.")
 	helpPtr := flag.Bool("help", false, "Display command line usage.")
+	versionPtr := flag.Bool("version", false, "Display current software version.")
 	flag.Parse()
+
+	if *versionPtr {
+		println(version, date)
+		return
+	}
 
 	if *helpPtr || len(flag.Args()) < 1 {
 		flag.Usage()

--- a/pcvalidate/pcvalidate.go
+++ b/pcvalidate/pcvalidate.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"runtime/debug"
 
 	vcsurl "github.com/alranel/go-vcsurl"
 	publiccode "github.com/italia/publiccode-parser-go"
@@ -18,10 +19,11 @@ var (
 
 func init() {
 	if version == "" {
-		version = "no version"
+		info, _ := debug.ReadBuildInfo()
+		version = info.Main.Version
 	}
 	if date == "" {
-		date = "(Mon YYYY)"
+		date = "(latest)"
 	}
 }
 


### PR DESCRIPTION
Firing `pcvalidate` it was not possible to get what version you have locally. Now, thanks to goreleaser every release will be tagged and binaries, for different archs, will have those information built in.
Typing `pcvalidate -version` actual version will be printed out.

Fix: #33 