### PR TITLE
fix nullpointer in container environment

### DIFF
--- a/pcvalidate/pcvalidate.go
+++ b/pcvalidate/pcvalidate.go
@@ -19,8 +19,10 @@ var (
 
 func init() {
 	if version == "" {
-		info, _ := debug.ReadBuildInfo()
-		version = info.Main.Version
+		version = "devel"
+		if info, ok := debug.ReadBuildInfo(); ok {
+			version = info.Main.Version
+		}
 	}
 	if date == "" {
 		date = "(latest)"


### PR DESCRIPTION
In some environment such as Docker, containers, `runtime/debug` is not available and it was causing a nullpointer trying to get right version.

fix #37 