### PR TITLE
Multiple domains support for token checks

### DIFF
--- a/check_generics.go
+++ b/check_generics.go
@@ -43,12 +43,21 @@ func getBasicAuth(domain Domain) string {
 	return ""
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func isHostInDomain(domain Domain, u string) bool {
-	if len(domain.Host) == 0 {
+	if len(domain.UseTokenFor) == 0 {
 		return false
 	}
-	url, _ := url.Parse(u)
-	if domain.Host == url.Host {
+	urlP, _ := url.Parse(u)
+	if stringInSlice(urlP.Host, domain.UseTokenFor) {
 		return true
 	}
 	return false

--- a/checks_test.go
+++ b/checks_test.go
@@ -11,14 +11,26 @@ type testURL struct {
 }
 
 func TestHostsInDomain(t *testing.T) {
+	domain := Domain{
+		UseTokenFor: []string{
+			"github.com",
+			"api.github.com",
+			"raw.githubusercontent.com",
+		},
+	}
+
 	list := []testURL{
-		{"https://github.com", Domain{Host: "github.com"}, true},
-		{"https://githubs.com", Domain{Host: "github.com"}, false},
-		{"https://github.org", Domain{Host: "github.com"}, false},
-		{"https://github", Domain{Host: "github.com"}, false},
-		{"http://github.com", Domain{Host: "github.com"}, true},
-		{"http:/github.com", Domain{Host: "github.com"}, false},
-		{"", Domain{Host: ""}, false},
+		{"https://github.com", domain, true},
+		{"https://githubs.com", domain, false},
+		{"https://github.org", domain, false},
+		{"https://github", domain, false},
+		{"http://github.com", domain, true},
+		{"http:/github.com", domain, false},
+		{"https://api.github.com", domain, true},
+		{"https://api.github.com/org/repo/file", domain, true},
+		{"https://raw.githubusercontent.com/org/repo/master/pc.yml", domain, true},
+		{"https://raw.githubusercontent.com", domain, true},
+		{"", Domain{UseTokenFor: []string{}}, false},
 		{"", Domain{}, false},
 	}
 	for _, l := range list {

--- a/parser.go
+++ b/parser.go
@@ -47,15 +47,17 @@ type Parser struct {
 // Domain is a single code hosting service.
 type Domain struct {
 	// Domains.yml data
-	Host      string   `yaml:"host"`
-	BasicAuth []string `yaml:"basic-auth"`
+	Host        string   `yaml:"host"`
+	UseTokenFor []string `yaml:"use-token-for"`
+	BasicAuth   []string `yaml:"basic-auth"`
 }
 
 // ParseInDomain wrapper func to be in domain env
-func (p *Parser) ParseInDomain(in []byte, host string, ba []string) error {
+func (p *Parser) ParseInDomain(in []byte, host string, utf []string, ba []string) error {
 	p.Domain = Domain{
-		Host:      host,
-		BasicAuth: ba,
+		Host:        host,
+		UseTokenFor: utf,
+		BasicAuth:   ba,
 	}
 
 	return p.Parse(in)


### PR DESCRIPTION
Some code hosting platform have multiple domains, in order to use authentication we must check every possibile domain in scope.