### PR TITLE
raise an error when a key list is empty instead panicking

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -185,7 +185,8 @@ func (p *Parser) decoderec(prefix string, s map[interface{}]interface{}) (es Err
 			}
 		default:
 			if v == nil {
-				panic(fmt.Errorf("key \"%s\" is empty. Remove it or fill with valid values", k))
+				es = append(es, newErrorInvalidValue(k, "is empty. Remove it or fill with valid values"))
+				return
 			}
 			panic(fmt.Errorf("key \"%s\" - invalid type: %T", k, v))
 		}

--- a/parser.go
+++ b/parser.go
@@ -184,11 +184,7 @@ func (p *Parser) decoderec(prefix string, s map[interface{}]interface{}) (es Err
 				es = append(es, errs...)
 			}
 		default:
-			if v == nil {
-				es = append(es, newErrorInvalidValue(k, "is empty. Remove it or fill with valid values"))
-				return
-			}
-			panic(fmt.Errorf("key \"%s\" - invalid type: %T", k, v))
+			es = append(es, newErrorInvalidValue(k, "invalid type %T.", v))
 		}
 	}
 	return

--- a/parser_test.go
+++ b/parser_test.go
@@ -45,6 +45,8 @@ func TestDecodeValueErrors(t *testing.T) {
 
 		// Invalid fields.
 		{"tests/invalid_legal_license.yml", "legal/license"}, // Invalid legal/license.
+		{"tests/nil_categories.yml", "categories"},           // Invalid categories (nil).
+		{"tests/nil_name.yml", "name"},                       // Invalid name (nil).
 	}
 
 	for _, test := range testFiles {

--- a/tests/nil_categories.yml
+++ b/tests/nil_categories.yml
@@ -1,0 +1,58 @@
+publiccodeYmlVersion: "0.1"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+softwareVersion: "dev"
+releaseDate: "2017-04-15"
+
+inputTypes:
+  - application/x.empty
+outputTypes:
+  - application/x.empty
+
+platforms:
+  - web
+
+# Should NOT validate: categories is nil
+categories:
+
+developmentStatus: development
+
+softwareType: "standalone"
+
+description:
+  eng:
+    localisedName: Medusa
+    genericName: Text Editor
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  license: AGPL-3.0-or-later
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: yes
+  availableLanguages:
+    - eng

--- a/tests/nil_name.yml
+++ b/tests/nil_name.yml
@@ -1,0 +1,58 @@
+publiccodeYmlVersion: "0.1"
+
+name:
+url: "https://github.com/italia/developers.italia.it.git"
+softwareVersion: "dev"
+releaseDate: "2017-04-15"
+
+inputTypes:
+  - application/x.empty
+outputTypes:
+  - application/x.empty
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone"
+
+description:
+  eng:
+    localisedName: Medusa
+    genericName: Text Editor
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  license: AGPL-3.0-or-later
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: yes
+  availableLanguages:
+    - eng


### PR DESCRIPTION
This will raise an error instead of brutal panic:

```
validation ko:
dependsOn/open: is empty. Remove it or fill with valid values
```

Fix: #43 