### PR TITLE
Ignore the protocol when checking the url key.

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -82,6 +82,13 @@ func (p *Parser) decodeString(key string, value string) (err error) {
 			if repo2 == nil {
 				return newErrorInvalidValue(key, "failed to detect repo for %s\n", url2.String())
 			}
+
+			// Let's ignore the schema when checking for equality.
+			//
+			// This is mainly to match repos regardless of whether they are served
+			// through HTTPS or HTTP.
+			repo1.Scheme, repo2.Scheme = "", ""
+
 			if !strings.EqualFold(repo1.String(), repo2.String()) {
 				return newErrorInvalidValue(
 					key,


### PR DESCRIPTION
Relax the check on the url key ignoring the protocol checking if
it matches with RemoteBaseURL.

This will make http://example.com/foo/bar and
https://example.com/foo/bar pass the test and be considered as
the same repo, which is pretty much always the case.

See developers-italia-backend#192