### PR TITLE
chore: pin goreleaser version to v1.5.0 and update config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.5.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,9 +40,7 @@ dockers:
   -
     goos: linux
     goarch: amd64
-    binaries:
-      - pcvalidate
-    builds:
+    ids:
       - pcvalidate
     skip_push: false
     dockerfile: Dockerfile.goreleaser


### PR DESCRIPTION
* Explicitly pin goreleaser version so the release process doesn't
  break when a new major of goreleaser gets out.

* Update .goreleaser.yml to reflect the current file format.
  (https://goreleaser.com/deprecations/#dockerbinaries,
   https://goreleaser.com/deprecations/#dockerbuilds)