### PR TITLE
chore: shrink the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
 # Accept the Go version for the image to be set as a build argument.
-ARG GO_VERSION=1.15-alpine
+ARG GO_VERSION=1.16-alpine
 
-FROM golang:${GO_VERSION}
-
-ENV BIN /usr/local/bin/pcvalidate
+FROM golang:${GO_VERSION} as build
 
 WORKDIR /go/src
 
 COPY . .
 
+RUN cd pcvalidate && \
+  go build -ldflags="-s -w" pcvalidate.go
+
+FROM alpine:3
+
+COPY --from=build /go/src/pcvalidate/pcvalidate /usr/local/bin/pcvalidate
+
 # git and openssh-client are needed by CircleCI when using
 # publiccode-parser-orb, which uses on this image.
-RUN apk --no-cache add git openssh-client \
-  && go build -o $BIN pcvalidate/pcvalidate.go \
-  && chmod +x $BIN
+RUN apk --no-cache add git openssh-client
 
 ENTRYPOINT ["/usr/local/bin/pcvalidate"]
 


### PR DESCRIPTION
Shrink down the final Docker image to 1/10th and use Go 1.16 for
building it.