### PR TITLE
chore: add labels to diff in file-freshness check

### DIFF
--- a/.github/workflows/file-freshness.js
+++ b/.github/workflows/file-freshness.js
@@ -49,7 +49,7 @@ console.log(`latest:  ${latestHash}`);
 let diff = ""
 
 try {
-  await $`diff -u ${localFileURL.pathname} /tmp/ipa_codes.txt.new`;
+  await $`diff -u --label old --label new ${localFileURL.pathname} /tmp/ipa_codes.txt.new`;
 } catch (p) {
     if (p == 2) {
         // Exit status 2 from "diff" means something went wrong


### PR DESCRIPTION
Add labels in diff, so that it's clearer which file is which and
in order to not update the issue with just the files' timestamps
if nothing changed in the diff.