### PR TITLE
test: add disabled test for BCP47 tag

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -380,6 +380,12 @@ func TestInvalidTestcasesV0_2(t *testing.T) {
 		"localisation_availableLanguages_invalid.yml": ValidationErrors{
 			ValidationError{"localisation.availableLanguages[0]", "must be a valid BCP 47 language", 56, 3},
 		},
+		// TODO: Enable this test when https://github.com/italia/publiccode-parser-go/issues/47
+		// is fixed
+		//
+		// "localisation_availableLanguages_invalid_bcp47.yml": ValidationErrors{
+		// 	ValidationError{"localisation.availableLanguages[0]", "must be a valid BCP 47 language", 56, 3},
+		// },
 		"localisation_localisationReady_missing.yml": ValidationErrors{
 			ValidationError{"localisation.localisationReady", "required", 58, 3},
 		},

--- a/testdata/v0.2/invalid/localisation_availableLanguages_invalid_bcp47.yml.disabled
+++ b/testdata/v0.2/invalid/localisation_availableLanguages_invalid_bcp47.yml.disabled
@@ -1,0 +1,60 @@
+publiccodeYmlVersion: "0.2"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+softwareVersion: "dev"
+releaseDate: "2017-04-15"
+
+inputTypes:
+  - application/x.empty
+outputTypes:
+  - application/x.empty
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone/other"
+
+description:
+  eng:
+    localisedName: Medusa
+    genericName: Text Editor
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  license: AGPL-3.0-or-later
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+     # Should NOT validate: even if this a valid POSIX language tag
+     # it's NOT a valid BCP47 language tag
+     - hr_HR


### PR DESCRIPTION
Go's language.Parse() is more lenient and allows non-BCP47 language
tags. Let's add a disabled test for now.

Related to #47.