### PR TITLE
chore: fix goreleaser's Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+#
+# This is for local development only.
+# See Dockerfile.goreleaser for the image published on release.
+#
+
 # Accept the Go version for the image to be set as a build argument.
 ARG GO_VERSION=1.16-alpine
 
@@ -14,10 +19,5 @@ FROM alpine:3
 
 COPY --from=build /go/src/pcvalidate/pcvalidate /usr/local/bin/pcvalidate
 
-# git and openssh-client are needed by CircleCI when using
-# publiccode-parser-orb, which uses on this image.
-RUN apk --no-cache add git openssh-client
-
 ENTRYPOINT ["/usr/local/bin/pcvalidate"]
-
 CMD ["files/publiccode.yml"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,14 @@
+#
+# This is the Docker image that gets published to DockerHub.
+# Goreleaser takes care of building the binary.
+#
 FROM alpine:3
 
-COPY pcvalidate /
+COPY pcvalidate /usr/local/bin/pcvalidate
 
-# Run the compiled binary.
-ENTRYPOINT ["/pcvalidate"]
+# git and openssh-client are needed by CircleCI when using
+# publiccode-parser-orb, which uses on this image.
+RUN apk --no-cache add git openssh-client
+
+ENTRYPOINT ["/usr/local/bin/pcvalidate"]
 CMD ["files/publiccode.yml"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,7 +7,7 @@ FROM alpine:3
 COPY pcvalidate /usr/local/bin/pcvalidate
 
 # git and openssh-client are needed by CircleCI when using
-# publiccode-parser-orb, which uses on this image.
+# publiccode-parser-orb, which uses this image.
 RUN apk --no-cache add git openssh-client
 
 ENTRYPOINT ["/usr/local/bin/pcvalidate"]


### PR DESCRIPTION
Fix goreleaser Dockerfile by moving the binary in the right directory
(within PATH) and make clear the purpose of the two Dockerfile in the
comments.