### PR TITLE
chore(deps): upgrade create-pull-request action

### DIFF
--- a/.github/workflows/file-freshness-pr.yml
+++ b/.github/workflows/file-freshness-pr.yml
@@ -14,7 +14,7 @@ jobs:
           | tail -n +2
           | cut -f1
           | LC_COLLATE=C sort > data/it/ipa_codes.txt
-      - uses: peter-evans/create-pull-request@v5
+      - uses: peter-evans/create-pull-request@v6
         with:
             commit-message: "chore: update it/ipa_codes.txt"
             title: "chore: update it/ipa_codes.txt"


### PR DESCRIPTION
Upgrade `peter-evans/create-pull-request` as GitHub changed their API and v6 is required to work properly.

See https://github.com/peter-evans/create-pull-request/issues/2790.