### PR TITLE
fix: properly validate countryExtensionVersion

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -81,13 +81,6 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 		}
 	}
 
-	if publiccodev0.It.CountryExtensionVersion != "" && publiccodev0.It.CountryExtensionVersion != "0.2" {
-		vr = append(vr, newValidationError(
-			"it.countryExtensionVersion",
-			"version %s not supported for country-specific section 'it'", publiccodev0.It.CountryExtensionVersion,
-		))
-	}
-
 	if len(publiccodev0.InputTypes) > 0 {
 		vr = append(vr, ValidationWarning{"inputTypes", "This key is DEPRECATED and will be removed in the future", 0, 0})
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -537,6 +537,9 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		},
 
 		// it.*
+		"it_countryExtensionVersion_invalid.yml": ValidationResults{
+			ValidationError{"it.countryExtensionVersion", "must be one of the following: 0.2 1.0", 12, 3},
+		},
 		"it_riuso_codiceIPA_invalid.yml": ValidationResults{
 			ValidationError{"it.riuso.codiceIPA", "must be a valid Italian Public Administration Code (iPA)", 55, 5},
 		},

--- a/v0.go
+++ b/v0.go
@@ -117,7 +117,7 @@ type DependencyV0 struct {
 // countries, such as declaring compliance with local laws or regulations.
 
 type ITSectionV0 struct {
-	CountryExtensionVersion string `yaml:"countryExtensionVersion"`
+	CountryExtensionVersion *string `yaml:"countryExtensionVersion" validate:"omitnil,oneof=0.2 1.0"`
 
 	Conforme struct {
 		LineeGuidaDesign        bool `yaml:"lineeGuidaDesign,omitempty"`


### PR DESCRIPTION
The standard states that countryExtensionVersion must be "1.0". Keep "0.2" for retrocompatibility, as that wasn't a great idea to bump it. The change was made when the process was not refined yet.

countryExtensionVersion should and will be deprecated anyway.