### PR TITLE
test: "eng" is not a valid BCP language

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -361,72 +361,72 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		"description_invalid_language.yml": ValidationResults{
 			ValidationError{"description", "must use a valid BCP 47 language", 18, 1},
 		},
-		"description_eng_features_missing.yml": ValidationResults{
-			ValidationError{"description.eng.features", "must be more than 0", 22, 5},
+		"description_en_features_missing.yml": ValidationResults{
+			ValidationError{"description.en.features", "must be more than 0", 22, 5},
 		},
-		"description_eng_features_empty.yml": ValidationResults{
-			ValidationError{"description.eng.features", "must be more than 0", 39, 5},
+		"description_en_features_empty.yml": ValidationResults{
+			ValidationError{"description.en.features", "must be more than 0", 39, 5},
 		},
-		"description_eng_localisedName_wrong_type.yml": ValidationResults{
-			ValidationError{"description.eng.localisedName", "wrong type for this field", 21, 1},
+		"description_en_localisedName_wrong_type.yml": ValidationResults{
+			ValidationError{"description.en.localisedName", "wrong type for this field", 21, 1},
 		},
-		"description_eng_genericName_too_long.yml": ValidationResults{
-			ValidationError{"description.eng.genericName", "must be less or equal than 35", 22, 5},
-			ValidationWarning{"description.eng.genericName", "This key is DEPRECATED and will be removed in the future", 22, 5},
+		"description_en_genericName_too_long.yml": ValidationResults{
+			ValidationError{"description.en.genericName", "must be less or equal than 35", 22, 5},
+			ValidationWarning{"description.en.genericName", "This key is DEPRECATED and will be removed in the future", 22, 5},
 		},
-		"description_eng_shortDescription_missing.yml": ValidationResults{
-			ValidationError{"description.eng.shortDescription", "required", 20, 5},
+		"description_en_shortDescription_missing.yml": ValidationResults{
+			ValidationError{"description.en.shortDescription", "required", 20, 5},
 		},
-		"description_eng_shortDescription_too_short.yml": ValidationResults{
-			ValidationError{"description.eng.shortDescription", "required", 20, 5},
+		"description_en_shortDescription_too_short.yml": ValidationResults{
+			ValidationError{"description.en.shortDescription", "required", 20, 5},
 		},
-		"description_eng_longDescription_missing.yml": ValidationResults{
-			ValidationError{"description.eng.longDescription", "required", 20, 5},
+		"description_en_longDescription_missing.yml": ValidationResults{
+			ValidationError{"description.en.longDescription", "required", 20, 5},
 		},
-		"description_eng_longDescription_too_long.yml": ValidationResults{
-			ValidationError{"description.eng.longDescription", "must be less or equal than 10000", 27, 5},
+		"description_en_longDescription_too_long.yml": ValidationResults{
+			ValidationError{"description.en.longDescription", "must be less or equal than 10000", 27, 5},
 		},
-		"description_eng_longDescription_too_short.yml": ValidationResults{
-			ValidationError{"description.eng.longDescription", "must be more or equal than 150", 27, 5},
+		"description_en_longDescription_too_short.yml": ValidationResults{
+			ValidationError{"description.en.longDescription", "must be more or equal than 150", 27, 5},
 		},
-		"description_eng_longDescription_too_short_grapheme_clusters.yml": ValidationResults{
-			ValidationError{"description.eng.longDescription", "must be more or equal than 150", 28, 5},
+		"description_en_longDescription_too_short_grapheme_clusters.yml": ValidationResults{
+			ValidationError{"description.en.longDescription", "must be more or equal than 150", 28, 5},
 		},
-		"description_eng_documentation_invalid.yml": ValidationResults{
-			ValidationError{"description.eng.documentation", "must be an HTTP URL", 25, 5},
-			ValidationError{"description.eng.documentation", "'not_a_url' not reachable: missing URL scheme", 25, 5},
+		"description_en_documentation_invalid.yml": ValidationResults{
+			ValidationError{"description.en.documentation", "must be an HTTP URL", 25, 5},
+			ValidationError{"description.en.documentation", "'not_a_url' not reachable: missing URL scheme", 25, 5},
 		},
-		"description_eng_documentation_wrong_type.yml": ValidationResults{
-			ValidationError{"description.eng.documentation", "wrong type for this field", 25, 1},
-			ValidationError{"description.eng.documentation", "must be an HTTP URL", 25, 5},
-			ValidationError{"description.eng.documentation", "'' not reachable: missing URL scheme", 25, 5},
+		"description_en_documentation_wrong_type.yml": ValidationResults{
+			ValidationError{"description.en.documentation", "wrong type for this field", 25, 1},
+			ValidationError{"description.en.documentation", "must be an HTTP URL", 25, 5},
+			ValidationError{"description.en.documentation", "'' not reachable: missing URL scheme", 25, 5},
 		},
-		"description_eng_apiDocumentation_invalid.yml": ValidationResults{
-			ValidationError{"description.eng.apiDocumentation", "must be an HTTP URL", 41, 5},
-			ValidationError{"description.eng.apiDocumentation", "'abc' not reachable: missing URL scheme", 41, 5},
+		"description_en_apiDocumentation_invalid.yml": ValidationResults{
+			ValidationError{"description.en.apiDocumentation", "must be an HTTP URL", 41, 5},
+			ValidationError{"description.en.apiDocumentation", "'abc' not reachable: missing URL scheme", 41, 5},
 		},
-		"description_eng_apiDocumentation_wrong_type.yml": ValidationResults{
-			ValidationError{"description.eng.apiDocumentation", "wrong type for this field", 43, 1},
-			ValidationError{"description.eng.apiDocumentation", "must be an HTTP URL", 43, 5},
-			ValidationError{"description.eng.apiDocumentation", "'' not reachable: missing URL scheme", 43, 5},
+		"description_en_apiDocumentation_wrong_type.yml": ValidationResults{
+			ValidationError{"description.en.apiDocumentation", "wrong type for this field", 43, 1},
+			ValidationError{"description.en.apiDocumentation", "must be an HTTP URL", 43, 5},
+			ValidationError{"description.en.apiDocumentation", "'' not reachable: missing URL scheme", 43, 5},
 		},
-		"description_eng_screenshots_missing_file.yml": ValidationResults{
+		"description_en_screenshots_missing_file.yml": ValidationResults{
 			ValidationError{
-				"description.eng.screenshots[0]",
+				"description.en.screenshots[0]",
 				"'no_such_file.png' is not an image: no such file : https://raw.githubusercontent.com/italia/developers.italia.it/main/no_such_file.png",
 				20,
 				5,
 			},
 		},
-		"description_eng_awards_wrong_type.yml": ValidationResults{
-			ValidationError{"description.eng.awards", "wrong type for this field", 40, 1},
+		"description_en_awards_wrong_type.yml": ValidationResults{
+			ValidationError{"description.en.awards", "wrong type for this field", 40, 1},
 		},
-		"description_eng_videos_invalid.yml": ValidationResults{
-			ValidationError{"description.eng.videos[0]", "must be an HTTP URL", 20, 5},
-			ValidationError{"description.eng.videos[0]", "'ABC' is not a valid video URL supporting oEmbed: invalid oEmbed link: ABC", 20, 5},
+		"description_en_videos_invalid.yml": ValidationResults{
+			ValidationError{"description.en.videos[0]", "must be an HTTP URL", 20, 5},
+			ValidationError{"description.en.videos[0]", "'ABC' is not a valid video URL supporting oEmbed: invalid oEmbed link: ABC", 20, 5},
 		},
-		"description_eng_videos_invalid_oembed.yml": ValidationResults{
-			ValidationError{"description.eng.videos[0]", "'https://google.com' is not a valid video URL supporting oEmbed: invalid oEmbed link: https://google.com", 20, 5},
+		"description_en_videos_invalid_oembed.yml": ValidationResults{
+			ValidationError{"description.en.videos[0]", "'https://google.com' is not a valid video URL supporting oEmbed: invalid oEmbed link: https://google.com", 20, 5},
 		},
 
 		// legal
@@ -586,7 +586,7 @@ func TestValidTestcasesV0(t *testing.T) {
 func TestValidWithWarningsTestcasesV0(t *testing.T) {
 	expected := map[string]error{
 		"unicode_grapheme_clusters.yml": ValidationResults{
-			ValidationWarning{"description.eng.genericName", "This key is DEPRECATED and will be removed in the future", 23, 5},
+			ValidationWarning{"description.en.genericName", "This key is DEPRECATED and will be removed in the future", 23, 5},
 		},
 		"valid.minimal.v0.2.yml": ValidationResults{
 			ValidationWarning{"publiccodeYmlVersion", "v0.2 is not the latest version, use '0.4.0'. Parsing this file as v0.4.0.", 1, 1},

--- a/testdata/v0/invalid/applicationSuite_wrong_type.yml
+++ b/testdata/v0/invalid/applicationSuite_wrong_type.yml
@@ -19,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/categories_empty.yml
+++ b/testdata/v0/invalid/categories_empty.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -49,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/categories_invalid.yml
+++ b/testdata/v0/invalid/categories_invalid.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/categories_missing.yml
+++ b/testdata/v0/invalid/categories_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -49,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/categories_nil.yml
+++ b/testdata/v0/invalid/categories_nil.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -49,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/dependsOn_open_name_wrong_type.yml
+++ b/testdata/v0/invalid/dependsOn_open_name_wrong_type.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,7 +48,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
 
 dependsOn:
   open:

--- a/testdata/v0/invalid/dependsOn_open_optional_wrong_type.yml
+++ b/testdata/v0/invalid/dependsOn_open_optional_wrong_type.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,7 +48,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
 
 dependsOn:
   open:

--- a/testdata/v0/invalid/dependsOn_open_versionMax_wrong_type.yml
+++ b/testdata/v0/invalid/dependsOn_open_versionMax_wrong_type.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,7 +48,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
 
 dependsOn:
   open:

--- a/testdata/v0/invalid/dependsOn_open_versionMin_wrong_type.yml
+++ b/testdata/v0/invalid/dependsOn_open_versionMin_wrong_type.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,7 +48,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
 
 dependsOn:
   open:

--- a/testdata/v0/invalid/dependsOn_open_version_wrong_type.yml
+++ b/testdata/v0/invalid/dependsOn_open_version_wrong_type.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,7 +48,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
 
 dependsOn:
   open:

--- a/testdata/v0/invalid/description_en_apiDocumentation_invalid.yml
+++ b/testdata/v0/invalid/description_en_apiDocumentation_invalid.yml
@@ -1,7 +1,9 @@
 publiccodeYmlVersion: "0.4"
 
 name: Medusa
+
 url: "https://github.com/italia/developers.italia.it.git"
+
 softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
@@ -16,8 +18,8 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
-    localisedName: Name
+  en:
+    localisedName: Medusa
     shortDescription: >
           A rather short description which
           is probably useless
@@ -34,11 +36,12 @@ description:
           Very long description of this software, also split
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
+
+    # Should NOT validate: must be a valid URL
+    apiDocumentation: 'abc'
+
     features:
-      - Feature 1
-    videos:
-      # Should NOT validate: not a valid URL
-      - ABC
+       - Just one feature
 
 legal:
   license: AGPL-3.0-or-later
@@ -52,4 +55,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_apiDocumentation_wrong_type.yml
+++ b/testdata/v0/invalid/description_en_apiDocumentation_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -54,4 +54,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_awards_wrong_type.yml
+++ b/testdata/v0/invalid/description_en_awards_wrong_type.yml
@@ -1,9 +1,7 @@
 publiccodeYmlVersion: "0.4"
 
 name: Medusa
-
 url: "https://github.com/italia/developers.italia.it.git"
-
 softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
@@ -18,12 +16,8 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
-    localisedName: Medusa
-
-    # Should NOT validate: documentation must be a string
-    documentation: []
-
+  en:
+    localisedName: Name
     shortDescription: >
           A rather short description which
           is probably useless
@@ -41,7 +35,9 @@ description:
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
     features:
-       - Just one feature
+      - Feature 1
+    # Should NOT validate: awards must be an array
+    awards: {}
 
 legal:
   license: AGPL-3.0-or-later
@@ -55,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_documentation_invalid.yml
+++ b/testdata/v0/invalid/description_en_documentation_invalid.yml
@@ -1,7 +1,10 @@
 publiccodeYmlVersion: "0.4"
 
 name: Medusa
+
 url: "https://github.com/italia/developers.italia.it.git"
+
+softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
 platforms:
@@ -14,12 +17,13 @@ developmentStatus: development
 
 softwareType: "standalone/other"
 
-# Should NOT validate: logo must exist as a file
-logo: "no_such_file.png"
-
 description:
   en:
     localisedName: Medusa
+
+    # Should NOT validate: must be a valid URL
+    documentation: 'not_a_url'
+
     shortDescription: >
           A rather short description which
           is probably useless

--- a/testdata/v0/invalid/description_en_documentation_wrong_type.yml
+++ b/testdata/v0/invalid/description_en_documentation_wrong_type.yml
@@ -1,7 +1,9 @@
 publiccodeYmlVersion: "0.4"
 
 name: Medusa
+
 url: "https://github.com/italia/developers.italia.it.git"
+
 softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
@@ -16,8 +18,12 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
+
+    # Should NOT validate: documentation must be a string
+    documentation: []
+
     shortDescription: >
           A rather short description which
           is probably useless
@@ -34,9 +40,8 @@ description:
           Very long description of this software, also split
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
-
-    # Should NOT validate: features is empty
-    features: []
+    features:
+       - Just one feature
 
 legal:
   license: AGPL-3.0-or-later
@@ -50,4 +55,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_features_empty.yml
+++ b/testdata/v0/invalid/description_en_features_empty.yml
@@ -16,10 +16,11 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
-    # Should NOT validate: shortDescription is missing
-    # shortDescription: ""
+    shortDescription: >
+          A rather short description which
+          is probably useless
     longDescription: >
           Very long description of this software, also split
           on multiple rows. You should note what the software
@@ -33,8 +34,9 @@ description:
           Very long description of this software, also split
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
-    features:
-       - Just one feature
+
+    # Should NOT validate: features is empty
+    features: []
 
 legal:
   license: AGPL-3.0-or-later
@@ -48,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_features_missing.yml
+++ b/testdata/v0/invalid/description_en_features_missing.yml
@@ -1,9 +1,7 @@
 publiccodeYmlVersion: "0.4"
 
 name: Medusa
-
 url: "https://github.com/italia/developers.italia.it.git"
-
 softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
@@ -18,12 +16,10 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
+    # Should NOT validate: features is missing
+    # features: []
     localisedName: Medusa
-
-    # Should NOT validate: must be a valid URL
-    documentation: 'not_a_url'
-
     shortDescription: >
           A rather short description which
           is probably useless
@@ -40,8 +36,6 @@ description:
           Very long description of this software, also split
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
-    features:
-       - Just one feature
 
 legal:
   license: AGPL-3.0-or-later
@@ -55,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_genericName_too_long.yml
+++ b/testdata/v0/invalid/description_en_genericName_too_long.yml
@@ -16,8 +16,10 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
-    localisedName: Name
+  en:
+    localisedName: Medusa
+    # Should not validate: genericName is more than 35 chars
+    genericName: 012345678901234567890123456789012345
     shortDescription: >
           A rather short description which
           is probably useless
@@ -35,9 +37,7 @@ description:
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
     features:
-      - Feature 1
-    # Should NOT validate: awards must be an array
-    awards: {}
+       - Just one feature
 
 legal:
   license: AGPL-3.0-or-later
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_localisedName_wrong_type.yml
+++ b/testdata/v0/invalid/description_en_localisedName_wrong_type.yml
@@ -16,10 +16,9 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
-    localisedName: Medusa
-    # Should not validate: genericName is more than 35 chars
-    genericName: 012345678901234567890123456789012345
+  en:
+    # Should NOT validate: localisedName is not a string
+    localisedName: []
     shortDescription: >
           A rather short description which
           is probably useless
@@ -37,7 +36,7 @@ description:
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
     features:
-       - Just one feature
+      - Feature 1
 
 legal:
   license: AGPL-3.0-or-later
@@ -51,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_longDescription_missing.yml
+++ b/testdata/v0/invalid/description_en_longDescription_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -38,4 +38,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_longDescription_too_long.yml
+++ b/testdata/v0/invalid/description_en_longDescription_too_long.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -159,4 +159,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_longDescription_too_short.yml
+++ b/testdata/v0/invalid/description_en_longDescription_too_short.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -40,4 +40,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_longDescription_too_short_grapheme_clusters.yml
+++ b/testdata/v0/invalid/description_en_longDescription_too_short_grapheme_clusters.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -54,4 +54,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_screenshots_missing_file.yml
+++ b/testdata/v0/invalid/description_en_screenshots_missing_file.yml
@@ -1,9 +1,7 @@
 publiccodeYmlVersion: "0.4"
 
 name: Medusa
-
 url: "https://github.com/italia/developers.italia.it.git"
-
 softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
@@ -18,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -36,12 +34,12 @@ description:
           Very long description of this software, also split
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
-
-    # Should NOT validate: must be a valid URL
-    apiDocumentation: 'abc'
-
     features:
-       - Just one feature
+      - Feature 1
+
+     # Should NOT validate: screenshot file does not exist
+    screenshots:
+      - no_such_file.png
 
 legal:
   license: AGPL-3.0-or-later
@@ -55,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_shortDescription_missing.yml
+++ b/testdata/v0/invalid/description_en_shortDescription_missing.yml
@@ -16,13 +16,10 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
-    # Should NOT validate: features is missing
-    # features: []
+  en:
     localisedName: Medusa
-    shortDescription: >
-          A rather short description which
-          is probably useless
+    # Should NOT validate: shortDescription is missing
+    # shortDescription: ""
     longDescription: >
           Very long description of this software, also split
           on multiple rows. You should note what the software
@@ -36,6 +33,8 @@ description:
           Very long description of this software, also split
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
 
 legal:
   license: AGPL-3.0-or-later
@@ -49,4 +48,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_videos_invalid.yml
+++ b/testdata/v0/invalid/description_en_videos_invalid.yml
@@ -16,9 +16,8 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
-    # Should NOT validate: localisedName is not a string
-    localisedName: []
+  en:
+    localisedName: Name
     shortDescription: >
           A rather short description which
           is probably useless
@@ -37,6 +36,9 @@ description:
           is and why one should need it. This is 632 characters.
     features:
       - Feature 1
+    videos:
+      # Should NOT validate: not a valid URL
+      - ABC
 
 legal:
   license: AGPL-3.0-or-later
@@ -50,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_en_videos_invalid_oembed.yml
+++ b/testdata/v0/invalid/description_en_videos_invalid_oembed.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Name
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/description_invalid_language.yml
+++ b/testdata/v0/invalid/description_invalid_language.yml
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/developmentStatus_invalid.yml
+++ b/testdata/v0/invalid/developmentStatus_invalid.yml
@@ -18,7 +18,7 @@ developmentStatus: "foobar"
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/developmentStatus_missing.yml
+++ b/testdata/v0/invalid/developmentStatus_missing.yml
@@ -18,7 +18,7 @@ categories:
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/developmentStatus_wrong_type.yml
+++ b/testdata/v0/invalid/developmentStatus_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: []
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/file_encoding.yml
+++ b/testdata/v0/invalid/file_encoding.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/inputTypes_invalid.yml
+++ b/testdata/v0/invalid/inputTypes_invalid.yml
@@ -20,7 +20,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -53,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/inputTypes_wrong_type.yml
+++ b/testdata/v0/invalid/inputTypes_wrong_type.yml
@@ -19,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_countries_invalid_country.yml
+++ b/testdata/v0/invalid/intendedAudience_countries_invalid_country.yml
@@ -23,7 +23,7 @@ intendedAudience:
       - DE
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -56,4 +56,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_countries_wrong_type.yml
+++ b/testdata/v0/invalid/intendedAudience_countries_wrong_type.yml
@@ -19,7 +19,7 @@ intendedAudience:
     countries: {}
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_scope_invalid_scope.yml
+++ b/testdata/v0/invalid/intendedAudience_scope_invalid_scope.yml
@@ -20,7 +20,7 @@ intendedAudience:
       - foobar
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -53,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_scope_wrong_type.yml
+++ b/testdata/v0/invalid/intendedAudience_scope_wrong_type.yml
@@ -19,7 +19,7 @@ intendedAudience:
     scope: {}
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_unsupportedCountries_invalid_country.yml
+++ b/testdata/v0/invalid/intendedAudience_unsupportedCountries_invalid_country.yml
@@ -20,7 +20,7 @@ intendedAudience:
       - Mouseton
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -53,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_unsupportedCountries_wrong_type.yml
+++ b/testdata/v0/invalid/intendedAudience_unsupportedCountries_wrong_type.yml
@@ -19,7 +19,7 @@ intendedAudience:
     unsupportedCountries: {}
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/intendedAudience_wrong_type.yml
+++ b/testdata/v0/invalid/intendedAudience_wrong_type.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 intendedAudience: []
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/invalid_yaml.yml
+++ b/testdata/v0/invalid/invalid_yaml.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/isBasedOn_wrong_type.yml
+++ b/testdata/v0/invalid/isBasedOn_wrong_type.yml
@@ -20,7 +20,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -53,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/it_countryExtensionVersion_invalid.yml
+++ b/testdata/v0/invalid/it_countryExtensionVersion_invalid.yml
@@ -2,11 +2,14 @@ publiccodeYmlVersion: "0.4"
 
 name: Medusa
 url: "https://github.com/italia/developers.italia.it.git"
-softwareVersion: "dev"
 releaseDate: "2017-04-15"
 
 platforms:
   - web
+
+# Should NOT validate: invalid countryExtensionVersion
+it:
+  countryExtensionVersion: "1.1"
 
 categories:
   - cloud-management
@@ -16,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -35,11 +38,7 @@ description:
           on multiple rows. You should note what the software
           is and why one should need it. This is 632 characters.
     features:
-      - Feature 1
-
-     # Should NOT validate: screenshot file does not exist
-    screenshots:
-      - no_such_file.png
+       - Just one feature
 
 legal:
   license: AGPL-3.0-or-later
@@ -53,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/it_riuso_codiceIPA_invalid.yml
+++ b/testdata/v0/invalid/it_riuso_codiceIPA_invalid.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,7 +48,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
 
 it:
   riuso:

--- a/testdata/v0/invalid/landingURL_invalid.yml
+++ b/testdata/v0/invalid/landingURL_invalid.yml
@@ -36,7 +36,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: "A really interesting software."
     longDescription: >
@@ -96,7 +96,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
     - ita
     - fra
     - deu

--- a/testdata/v0/invalid/legal_authorsFile_missing_file.yml
+++ b/testdata/v0/invalid/legal_authorsFile_missing_file.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/legal_license_invalid.yml
+++ b/testdata/v0/invalid/legal_license_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/legal_license_missing.yml
+++ b/testdata/v0/invalid/legal_license_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/legal_missing.yml
+++ b/testdata/v0/invalid/legal_missing.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,4 +48,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/legal_wrong_type.yml
+++ b/testdata/v0/invalid/legal_wrong_type.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,4 +48,4 @@ legal: []
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/localisation_availableLanguages_empty.yml
+++ b/testdata/v0/invalid/localisation_availableLanguages_empty.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which

--- a/testdata/v0/invalid/localisation_availableLanguages_invalid.yml
+++ b/testdata/v0/invalid/localisation_availableLanguages_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which

--- a/testdata/v0/invalid/localisation_availableLanguages_invalid_bcp47.yml.disabled
+++ b/testdata/v0/invalid/localisation_availableLanguages_invalid_bcp47.yml.disabled
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which

--- a/testdata/v0/invalid/localisation_availableLanguages_missing.yml
+++ b/testdata/v0/invalid/localisation_availableLanguages_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ localisation:
   localisationReady: true
   # Should NOT validate: availableLanguages is missing
   # availableLanguages:
-  #   - eng
+  #   - en

--- a/testdata/v0/invalid/localisation_localisationReady_missing.yml
+++ b/testdata/v0/invalid/localisation_localisationReady_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ localisation:
   # Should not validate: localisationReady is missing
   # localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/logo_unsupported_extension.yml
+++ b/testdata/v0/invalid/logo_unsupported_extension.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 logo: "logo.mpg"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/logo_wrong_type.yml
+++ b/testdata/v0/invalid/logo_wrong_type.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 logo: []
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contacts_email_invalid.yml
+++ b/testdata/v0/invalid/maintenance_contacts_email_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contacts_missing_with_type_community.yml
+++ b/testdata/v0/invalid/maintenance_contacts_missing_with_type_community.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contacts_missing_with_type_internal.yml
+++ b/testdata/v0/invalid/maintenance_contacts_missing_with_type_internal.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contacts_name_missing.yml
+++ b/testdata/v0/invalid/maintenance_contacts_name_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_email_invalid.yml
+++ b/testdata/v0/invalid/maintenance_contractors_email_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_invalid_type.yml
+++ b/testdata/v0/invalid/maintenance_contractors_invalid_type.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -49,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_missing_with_type_contract.yml
+++ b/testdata/v0/invalid/maintenance_contractors_missing_with_type_contract.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_name_missing.yml
+++ b/testdata/v0/invalid/maintenance_contractors_name_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_until_invalid.yml
+++ b/testdata/v0/invalid/maintenance_contractors_until_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_until_missing.yml
+++ b/testdata/v0/invalid/maintenance_contractors_until_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_contractors_website_invalid.yml
+++ b/testdata/v0/invalid/maintenance_contractors_website_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -54,4 +54,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_type_invalid.yml
+++ b/testdata/v0/invalid/maintenance_type_invalid.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/maintenance_type_missing.yml
+++ b/testdata/v0/invalid/maintenance_type_missing.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/monochromeLogo_missing_file.yml
+++ b/testdata/v0/invalid/monochromeLogo_missing_file.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 monochromeLogo: "no_such_file.png"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/monochromeLogo_unsupported_extension.yml
+++ b/testdata/v0/invalid/monochromeLogo_unsupported_extension.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 monochromeLogo: "monochromeLogo.mpg"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/monochromeLogo_wrong_type.yml
+++ b/testdata/v0/invalid/monochromeLogo_wrong_type.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 monochromeLogo: []
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/name_missing.yml
+++ b/testdata/v0/invalid/name_missing.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/name_nil.yml
+++ b/testdata/v0/invalid/name_nil.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/name_wrong_type.yml
+++ b/testdata/v0/invalid/name_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/no-network/landingURL_invalid.yml
+++ b/testdata/v0/invalid/no-network/landingURL_invalid.yml
@@ -36,7 +36,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: "A really interesting software."
     longDescription: >
@@ -96,7 +96,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
     - ita
     - fra
     - deu

--- a/testdata/v0/invalid/no-network/logo_invalid_png.yml
+++ b/testdata/v0/invalid/no-network/logo_invalid_png.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 logo: "testdata/img/not-an-image.png"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/no-network/logo_missing_file.yml
+++ b/testdata/v0/invalid/no-network/logo_missing_file.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 logo: "no_such_file.png"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/no-network/monochromeLogo_invalid_png.yml
+++ b/testdata/v0/invalid/no-network/monochromeLogo_invalid_png.yml
@@ -18,7 +18,7 @@ softwareType: "standalone/other"
 monochromeLogo: "testdata/img/not-an-image.png"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/outputTypes_invalid.yml
+++ b/testdata/v0/invalid/outputTypes_invalid.yml
@@ -20,7 +20,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -53,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/outputTypes_wrong_type.yml
+++ b/testdata/v0/invalid/outputTypes_wrong_type.yml
@@ -19,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/platforms_missing.yml
+++ b/testdata/v0/invalid/platforms_missing.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/platforms_wrong_type.yml
+++ b/testdata/v0/invalid/platforms_wrong_type.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -49,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/publiccodeYmlVersion_invalid.yml
+++ b/testdata/v0/invalid/publiccodeYmlVersion_invalid.yml
@@ -49,4 +49,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/publiccodeYmlVersion_missing.yml
+++ b/testdata/v0/invalid/publiccodeYmlVersion_missing.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/publiccodeYmlVersion_wrong_type.yml
+++ b/testdata/v0/invalid/publiccodeYmlVersion_wrong_type.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/releaseDate_empty.yml
+++ b/testdata/v0/invalid/releaseDate_empty.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/releaseDate_invalid.yml
+++ b/testdata/v0/invalid/releaseDate_invalid.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/releaseDate_wrong_type.yml
+++ b/testdata/v0/invalid/releaseDate_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/roadmap_invalid.yml
+++ b/testdata/v0/invalid/roadmap_invalid.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/roadmap_wrong_type.yml
+++ b/testdata/v0/invalid/roadmap_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/softwareType_invalid.yml
+++ b/testdata/v0/invalid/softwareType_invalid.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 softwareType: "foobar"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/softwareType_missing.yml
+++ b/testdata/v0/invalid/softwareType_missing.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 # softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/softwareType_wrong_type.yml
+++ b/testdata/v0/invalid/softwareType_wrong_type.yml
@@ -17,7 +17,7 @@ developmentStatus: development
 softwareType: []
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -50,4 +50,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/softwareVersion_wrong_type.yml
+++ b/testdata/v0/invalid/softwareVersion_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/url_invalid.yml
+++ b/testdata/v0/invalid/url_invalid.yml
@@ -19,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/url_missing.yml
+++ b/testdata/v0/invalid/url_missing.yml
@@ -19,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/url_wrong_type.yml
+++ b/testdata/v0/invalid/url_wrong_type.yml
@@ -19,7 +19,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -52,4 +52,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/invalid/usedBy_wrong_type.yml
+++ b/testdata/v0/invalid/usedBy_wrong_type.yml
@@ -18,7 +18,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -51,4 +51,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/valid/countryExtensionVersion_1.0.yml
+++ b/testdata/v0/valid/countryExtensionVersion_1.0.yml
@@ -3,9 +3,7 @@ publiccodeYmlVersion: "0.4"
 name: Medusa
 applicationSuite: MegaProductivitySuite
 url: "https://github.com/italia/developers.italia.it.git"
-
-# Should not validate: landingURL must be a string
-landingURL: []
+landingURL: "https://developers.italia.it"
 
 isBasedOn: "https://github.com/italia/developers.italia.it.git"
 softwareVersion: "1.0"
@@ -61,33 +59,22 @@ description:
        - Will run without a problem
        - Has zero bugs
        - Solves all the problems of the world
+    videos:
+       - https://www.youtube.com/watch?v=RaHmGbBOP84
+    awards:
+       - 1st Price Software of the year
 
 legal:
-  license: AGPL-3.0-or-later        # SPDX expression of license
+  license: AGPL-3.0-or-later
   mainCopyrightOwner: City of Chicago
   repoOwner: City of Chicago
 
 maintenance:
-  type: "contract"
-
-  contractors:
-    - name: "Fornitore Privato SPA" # if maintainance is a contract
-      website: "https://developers.italia.it"
-      until: "2019-01-01"
-
+  type: "community"
   contacts:
-    - name: Francesco Rossi
-      email: "francesco.rossi@comune.reggioemilia.it"
-      affiliation: Comune di Reggio Emilia
-      phone: +39 231 13215112
-    - name: Dario Bianchi
-      email: "dario.bianchi@fornitore.it"
-      affiliation: Fornitore Privato S.P.A.
-      phone: +39 16 24231322
-    - name: Giancarlo Verdi
-      email: "dario.bianchi@fornitore.it"
-      affiliation: Fornitore Privato S.P.A.
-      phone: +39 16 24231322
+    - email: mrossi@cittametropolitana.it
+      name: Mario Rossi
+      phone: '+390412501953'
 
 localisation:
   localisationReady: true
@@ -109,23 +96,27 @@ dependsOn:
   proprietary:
     - name: Oracle
       versionMin: "11.4"
-    - name: IBM SoftLayer
   hardware:
     - name: NFC Reader
       optional: true
+    - name: NFC Reader1
+      optional: true
+    - name: NFC Reader2
+      optional: true
 
 it:
+  countryExtensionVersion: "1.0"
   conforme:
-    lineeGuidaDesign: true
-    modelloInteroperabilita: true
-    misureMinimeSicurezza: true
-    gdpr: true
+    lineeGuidaDesign: false
+    modelloInteroperabilita: false
+    misureMinimeSicurezza: false
+    gdpr: false
 
   riuso:
     codiceIPA: c_h501
 
   piattaforme:
-    spid: true
-    pagopa: true
-    cie: true
-    anpr: true
+    spid: false
+    pagopa: false
+    cie: false
+    anpr: false

--- a/testdata/v0/valid/dependsOn.yml
+++ b/testdata/v0/valid/dependsOn.yml
@@ -35,7 +35,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: "A really interesting software."
     longDescription: >
@@ -82,7 +82,7 @@ localisation:
   localisationReady: true
   # Languages already available
   availableLanguages:
-    - eng
+    - en
     - ita
     - fra
     - deu

--- a/testdata/v0/valid/maintenance_contacts_phone.yml
+++ b/testdata/v0/valid/maintenance_contacts_phone.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -59,4 +59,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/valid/no-network/valid.yml
+++ b/testdata/v0/valid/no-network/valid.yml
@@ -139,7 +139,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: "A really interesting software."
     longDescription: >
@@ -203,7 +203,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
     - ita
     - fra
     - deu

--- a/testdata/v0/valid/valid.minimal.yml
+++ b/testdata/v0/valid/valid.minimal.yml
@@ -47,4 +47,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/valid/valid.yml
+++ b/testdata/v0/valid/valid.yml
@@ -142,7 +142,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: "A really interesting software."
     longDescription: >
@@ -202,7 +202,7 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en
     - ita
     - fra
     - deu

--- a/testdata/v0/valid_with_warnings/no-network/authorsFile.yml
+++ b/testdata/v0/valid_with_warnings/no-network/authorsFile.yml
@@ -35,7 +35,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: "A really interesting software."
     longDescription: >
@@ -83,7 +83,7 @@ localisation:
   localisationReady: true
   # Languages already available
   availableLanguages:
-    - eng
+    - en
     - ita
     - fra
     - deu

--- a/testdata/v0/valid_with_warnings/unicode_grapheme_clusters.yml
+++ b/testdata/v0/valid_with_warnings/unicode_grapheme_clusters.yml
@@ -16,7 +16,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
 
     # This is 14 characters long and below this field's limit of 35 characters.
@@ -53,4 +53,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/valid_with_warnings/valid.minimal.v0.2.yml
+++ b/testdata/v0/valid_with_warnings/valid.minimal.v0.2.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,4 +48,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en

--- a/testdata/v0/valid_with_warnings/valid.minimal.v0.3.yml
+++ b/testdata/v0/valid_with_warnings/valid.minimal.v0.3.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone/other"
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     shortDescription: >
           A rather short description which
@@ -48,4 +48,4 @@ maintenance:
 localisation:
   localisationReady: true
   availableLanguages:
-    - eng
+    - en


### PR DESCRIPTION
Change the tests so there's no invalid BCP "eng" language.

We don't catch that as an error yet because of #47.