### PR TITLE
feat: support WITH in SPDX license expressions

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alranel/go-vcsurl/v2"
 	urlutil "github.com/italia/publiccode-parser-go/v4/internal"
-	spdxValidator "github.com/kyoh86/go-spdx/spdx"
 )
 
 type validateFn func(publiccode PublicCode, parser Parser, network bool) error
@@ -18,7 +17,6 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 	publiccodev0 := publiccode.(PublicCodeV0)
 
 	var vr ValidationResults
-	var err error
 
 	if publiccodev0.URL != nil && network {
 		if reachable, err := parser.isReachable(*(*url.URL)(publiccodev0.URL), network); !reachable {
@@ -67,16 +65,6 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 			u := toCodeHostingURL(*publiccodev0.Legal.AuthorsFile, parser.baseURL)
 
 			vr = append(vr, newValidationError("legal.authorsFile", "'%s' does not exist", urlutil.DisplayURL(&u)))
-		}
-	}
-
-	if publiccodev0.Legal.License != "" {
-		_, err = spdxValidator.Parse(publiccodev0.Legal.License)
-		if err != nil {
-			vr = append(vr, newValidationError(
-				"legal.license",
-				"invalid license '%s'", publiccodev0.Legal.License,
-			))
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/italia/publiccode-parser-go/v4
 require (
 	github.com/alranel/go-vcsurl/v2 v2.0.2
 	github.com/dyatlov/go-oembed v0.0.0-20191103150536-a57c85b3b37c
+	github.com/github/go-spdx/v2 v2.3.3
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.18.0
 	github.com/italia/httpclient-lib-go v0.0.2
-	github.com/kyoh86/go-spdx v0.0.5-0.20220518012447-4d195d3a5da1
 	github.com/rivo/uniseg v0.4.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/dyatlov/go-oembed v0.0.0-20191103150536-a57c85b3b37c h1:MEV1LrQtCBGac
 github.com/dyatlov/go-oembed v0.0.0-20191103150536-a57c85b3b37c/go.mod h1:DjlDZiZGRRKbiJZmiEiiXozsBQAQzHmxwHKFeXifL2g=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
+github.com/github/go-spdx/v2 v2.3.3 h1:QI7evnHWEfWkT54eJwkoV/f3a0xD3gLlnVmT5wQG6LE=
+github.com/github/go-spdx/v2 v2.3.3/go.mod h1:2ZxKsOhvBp+OYBDlsGnUMcchLeo2mrpEBn2L1C+U3IQ=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -24,8 +26,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kyoh86/go-spdx v0.0.5-0.20220518012447-4d195d3a5da1 h1:V9VECvxFpeRc1dQGZyB2rOsUOAcDKi+t2sV64UK8xE4=
-github.com/kyoh86/go-spdx v0.0.5-0.20220518012447-4d195d3a5da1/go.mod h1:PLyaOnItOIGepc7kUKJbp2YSsaZf94luSUcUgb2MQ+4=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -37,7 +37,6 @@ github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/parser_test.go
+++ b/parser_test.go
@@ -438,7 +438,7 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		},
 		"legal_license_missing.yml": ValidationResults{ValidationError{"legal.license", "license is a required field", 41, 3}},
 		"legal_license_invalid.yml": ValidationResults{ValidationError{
-			"legal.license", "invalid license 'Invalid License'", 42, 3,
+			"legal.license", "license must be a valid license (see https://spdx.org/licenses)", 42, 3,
 		}},
 		"legal_authorsFile_missing_file.yml": ValidationResults{
 			ValidationWarning{

--- a/testdata/v0/valid/valid_spdx_or.yml
+++ b/testdata/v0/valid/valid_spdx_or.yml
@@ -1,0 +1,51 @@
+publiccodeYmlVersion: "0.4"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone/other"
+
+description:
+  en_GB:
+    localisedName: Medusa
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  # OR operator in SPDX expression
+  license: MIT OR Apache-2.0
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en

--- a/testdata/v0/valid/valid_spdx_with.yml
+++ b/testdata/v0/valid/valid_spdx_with.yml
@@ -1,0 +1,51 @@
+publiccodeYmlVersion: "0.4"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone/other"
+
+description:
+  en_GB:
+    localisedName: Medusa
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  # WITH exception in SPDX expression
+  license: MIT WITH Bison-exception-2.2
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en

--- a/v0.go
+++ b/v0.go
@@ -44,7 +44,7 @@ type PublicCodeV0 struct {
 	Description map[string]DescV0 `yaml:"description" validate:"gt=0,bcp47_keys,dive"`
 
 	Legal struct {
-		License            string  `yaml:"license" validate:"required"`
+		License            string  `yaml:"license" validate:"required,is_spdx_expression"`
 		MainCopyrightOwner *string `yaml:"mainCopyrightOwner,omitempty"`
 		RepoOwner          *string `yaml:"repoOwner,omitempty"`
 		AuthorsFile        *string `yaml:"authorsFile,omitempty"`

--- a/validators/common.go
+++ b/validators/common.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/github/go-spdx/v2/spdxexp"
 	"github.com/go-playground/validator/v10"
 	"github.com/rivo/uniseg"
 )
@@ -87,4 +88,10 @@ func bcp47_keys(fl validator.FieldLevel) bool {
 	}
 
 	return true
+}
+
+func isSPDXExpression(fl validator.FieldLevel) bool {
+	valid, _ := spdxexp.ValidateLicenses([]string{fl.Field().String()})
+
+	return valid
 }

--- a/validators/validator.go
+++ b/validators/validator.go
@@ -18,6 +18,7 @@ func New() *validator.Validate {
 	_ = validate.RegisterValidation("umin", uMin)
 	_ = validate.RegisterValidation("url_http_url", isHTTPURL)
 	_ = validate.RegisterValidation("url_url", isURL)
+	_ = validate.RegisterValidation("is_spdx_expression", isSPDXExpression)
 
 	_ = validate.RegisterValidation("is_category_v0", isCategoryV0)
 	_ = validate.RegisterValidation("is_scope_v0", isScopeV0)
@@ -124,6 +125,10 @@ func RegisterLocalErrorMessages(v *validator.Validate, trans ut.Translator) erro
 		{
 			tag:         "url_url",
 			translation: "{0} must be a valid URL",
+		},
+		{
+			tag:         "is_spdx_expression",
+			translation: "{0} must be a valid license (see https://spdx.org/licenses)",
 		},
 		{
 			tag:         "is_category_v0",


### PR DESCRIPTION
Use https://github.com/github/go-spdx to validate SPDX license expressions: it's more maintained and supports WITH exceptions.

Also, make it a function for go-playground/validator.

Fix #189.