### PR TITLE
chore(ci): build multiplatform Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ jobs:
         with:
           go-version: '1.23'
         id: go
+
+      # Needed to build multi-platform Docker images
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       -
         name: Checkout
         uses: actions/checkout@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,12 +49,36 @@ changelog:
     - '^test:'
 dockers:
   -
+    use: buildx
     goos: linux
     goarch: amd64
     ids:
       - publiccode-parser
-    skip_push: false
     dockerfile: Dockerfile.goreleaser
     image_templates:
-      - "italia/publiccode-parser-go:latest"
-      - "italia/publiccode-parser-go:{{ .Tag }}"
+      - "italia/publiccode-parser-go:{{ .Tag }}-amd64"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+  -
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - publiccode-parser
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - "italia/publiccode-parser-go:{{ .Tag }}-arm64"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "italia/publiccode-parser-go:latest"
+    image_templates:
+      - "italia/publiccode-parser-go:{{ .Tag }}-amd64"
+      - "italia/publiccode-parser-go:{{ .Tag }}-arm64"
+  - name_template: "italia/publiccode-parser-go:{{ .Tag }}"
+    image_templates:
+      - "italia/publiccode-parser-go:{{ .Tag }}-amd64"
+      - "italia/publiccode-parser-go:{{ .Tag }}-arm64"


### PR DESCRIPTION
Build multi-platform Docker image (https://goreleaser.com/cookbooks/multi-platform-docker-images/#creating-multi-platform-docker-images-with-goreleaser), with arm64.

Fix #201.