### PR TITLE
refactor: use the alias feature for date validation

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -224,6 +224,9 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		"releaseDate_invalid.yml": ValidationResults{
 			ValidationError{"releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1},
 		},
+		"releaseDate_datetime.yml": ValidationResults{
+			ValidationError{"releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1},
+		},
 
 		// logo
 		"logo_wrong_type.yml": ValidationResults{

--- a/validators/common.go
+++ b/validators/common.go
@@ -6,18 +6,11 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/github/go-spdx/v2/spdxexp"
 	"github.com/go-playground/validator/v10"
 	"github.com/rivo/uniseg"
 )
-
-func isDate(fl validator.FieldLevel) bool {
-	_, err := time.Parse("2006-01-02", fl.Field().String())
-
-	return err == nil
-}
 
 func isIso3166Alpha2Lowercase(fl validator.FieldLevel) bool {
 	str := fl.Field().String()

--- a/validators/validator.go
+++ b/validators/validator.go
@@ -12,7 +12,6 @@ import (
 
 func New() *validator.Validate {
 	validate := validator.New(validator.WithRequiredStructEnabled())
-	_ = validate.RegisterValidation("date", isDate)
 	_ = validate.RegisterValidation("is_mime_type", isMIMEType)
 	_ = validate.RegisterValidation("iso3166_1_alpha2_lowercase", isIso3166Alpha2Lowercase)
 	_ = validate.RegisterValidation("umax", uMax)
@@ -27,6 +26,8 @@ func New() *validator.Validate {
 	_ = validate.RegisterValidation("is_italian_ipa_code", isItalianIpaCode)
 
 	_ = validate.RegisterValidation("bcp47_keys", bcp47_keys)
+
+	validate.RegisterAlias("date", "datetime=2006-01-02")
 
 	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
 		name := strings.SplitN(fld.Tag.Get("yaml"), ",", 2)[0]


### PR DESCRIPTION
Use the builtin validator and the nice alias feature of the validation library, and add a test for good measure.