### PR TITLE
fix: allow "0" as publiccodeYmlVersion

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -135,7 +135,7 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) {
 
 	var ve ValidationResults
 
-	if slices.Contains(SupportedVersions, version.Value) && !strings.HasPrefix(version.Value, "0.4") {
+	if slices.Contains(SupportedVersions, version.Value) && version.Value != "0" && !strings.HasPrefix(version.Value, "0.4") {
 		latestVersion := SupportedVersions[len(SupportedVersions)-1]
 		line, column := getPositionInFile("publiccodeYmlVersion", node)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -151,7 +151,7 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		"publiccodeYmlVersion_invalid.yml": ValidationResults{
 			ValidationError{
 				"publiccodeYmlVersion",
-				"unsupported version: '1'. Supported versions: 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0",
+				"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0",
 				0,
 				0,
 			},

--- a/publiccode.go
+++ b/publiccode.go
@@ -1,7 +1,7 @@
 package publiccode
 
 // SupportedVersions lists the publiccode.yml versions this parser supports.
-var SupportedVersions = []string{"0.2", "0.2.0", "0.2.1", "0.2.2", "0.3", "0.3.0", "0.4", "0.4.0"}
+var SupportedVersions = []string{"0", "0.2", "0.2.0", "0.2.1", "0.2.2", "0.3", "0.3.0", "0.4", "0.4.0"}
 
 type PublicCode interface {
 	Version() uint

--- a/testdata/v0/valid/valid_with_major_version.yml
+++ b/testdata/v0/valid/valid_with_major_version.yml
@@ -1,0 +1,51 @@
+# Should validate with just 0 as the major version 
+publiccodeYmlVersion: "0"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone/other"
+
+description:
+  en_GB:
+    localisedName: Medusa
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  license: AGPL-3.0-or-later
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en

--- a/v0.go
+++ b/v0.go
@@ -7,7 +7,7 @@ import (
 
 // PublicCodeV0 defines how a publiccode.yml v0.x is structured
 type PublicCodeV0 struct {
-	PubliccodeYamlVersion string `validate:"required,oneof=0.2 0.2.0 0.2.1 0.2.2 0.3 0.3.0 0.4 0.4.0" yaml:"publiccodeYmlVersion"`
+	PubliccodeYamlVersion string `validate:"required,oneof=0 0.2 0.2.0 0.2.1 0.2.2 0.3 0.3.0 0.4 0.4.0" yaml:"publiccodeYmlVersion"`
 
 	Name             string `validate:"required"               yaml:"name"`
 	ApplicationSuite string `yaml:"applicationSuite,omitempty"`


### PR DESCRIPTION
This is basically what specifying the version does: it refers to the major version and the validator acts on it.

Make it explicitly supported.