### PR TITLE
fix: add os.Exit and log.Fatal.* to forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,6 +93,8 @@ linters:
       forbid:
         - pattern: ^(fmt\.Print(|f|ln)|print|println)$
         - pattern: ^panic$
+        - pattern: ^log\.Fatal.*$
+        - pattern: ^os\.Exit$
 
   exclusions:
     generated: lax

--- a/internal/netutil.go
+++ b/internal/netutil.go
@@ -2,8 +2,8 @@ package netutil
 
 import (
 	"bytes"
+	"fmt"
 	"io"
-	"log"
 	"net/url"
 	"os"
 	"path"
@@ -43,7 +43,7 @@ func DownloadTmpFile(url *url.URL, headers map[string]string) (string, error) {
 	// Create a temp dir
 	tmpdir, err := os.MkdirTemp("", "publiccode.yml-parser-go")
 	if err != nil {
-		log.Fatal(err)
+		return "", fmt.Errorf("creating temp dir: %w", err)
 	}
 
 	// Download the file in the temp dir.

--- a/validators/validator.go
+++ b/validators/validator.go
@@ -205,6 +205,7 @@ func RegisterLocalErrorMessages(v *validator.Validate, trans ut.Translator) erro
 func registrationFunc(tag string, translation string, override bool) validator.RegisterTranslationsFunc {
 	return func(ut ut.Translator) error {
 		if err := ut.Add(tag, translation, override); err != nil {
+			//nolint:forbidigo // Programming error caught at runtime, it's right to panic
 			log.Fatalf("Error %s", err.Error())
 
 			return err


### PR DESCRIPTION
We should never panic in the library