### PR TITLE
fix: always set currentBaseURL and don't do checks on WASM

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -238,6 +238,10 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) {
 			p.currentBaseURL = &u
 			p.currentBaseURL.Path = path.Dir(p.fileURL.Path)
 		}
+	} else {
+		u := *p.baseURL
+
+		p.currentBaseURL = &u
 	}
 
 	// Still no base URL: we parsed from a stream, try to use the publiccode.yml's `url` field

--- a/validations.go
+++ b/validations.go
@@ -117,6 +117,11 @@ func toCodeHostingURL(file string, baseURL *url.URL) url.URL {
 
 // fileExists returns true if the file resource exists.
 func (p *Parser) fileExists(u url.URL, network bool) (bool, error) {
+	// Don't check if we are running in WASM because there's no stat(2) there
+	if runtime.GOARCH == "wasm" {
+		return true, nil
+	}
+
 	// If we have an absolute local path, perform validation on it, otherwise do it
 	// on the remote URL if any. If none are available, validation is skipped.
 	if u.Scheme == "file" {


### PR DESCRIPTION
currentBaseURL was not always set as it should've been.

Also, since starting from ac7642ab8 we try to properly check local files when we should, disable them on WASM because likely there's no actual filesystem in that case.