### PR TITLE
chore(lint): bump golangci-lint to v2.5.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: "1.25"
       - uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6
+          version: v2.5.0
           args: --timeout 3m --verbose

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,6 +28,10 @@ linters:
     # https://github.com/italia/developers-italia-api/issues/190)
     # Don't feel about chasing this one down
     - musttag
+    # Meh
+    - noinlineerr
+    # Deprecated
+    - wsl
 
     # More false positive than actual issues
     - mnd

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// A generic parse error.
+// ParseError is generic parse error.
 type ParseError struct {
 	Reason string
 }
@@ -36,6 +36,7 @@ func (e ValidationError) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(&struct {
 		*Ve
+
 		Type string `json:"type"`
 	}{
 		Ve:   (*Ve)(&e),
@@ -63,6 +64,7 @@ func (e ValidationWarning) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(&struct {
 		*Ve
+
 		Type string `json:"type"`
 	}{
 		Ve:   (*Ve)(&e),

--- a/internal/netutil.go
+++ b/internal/netutil.go
@@ -38,6 +38,7 @@ func downloadFile(filepath string, url *url.URL, headers map[string]string) erro
 	return err
 }
 
+// DownloadTmpFile downloads the passed URL to a temporary directory.
 // Caller is responsible for removing the temporary directory.
 func DownloadTmpFile(url *url.URL, headers map[string]string) (string, error) {
 	// Create a temp dir


### PR DESCRIPTION
* disable noinlineerr
  Not really useful IMO and just adds noise.
* disable wsl
  wsl is deprecated