### PR TITLE
feat: improve retrocompatibility

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -16,7 +16,7 @@ type validateFn func(publiccode PublicCode, parser Parser, network bool) error
 // with a simple YAML schema.
 // It returns any error encountered as ValidationResults.
 func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error { //nolint:maintidx
-	publiccodev0 := publiccode.(PublicCodeV0)
+	publiccodev0 := publiccode.(*PublicCodeV0)
 
 	var vr ValidationResults
 

--- a/v0.go
+++ b/v0.go
@@ -20,10 +20,7 @@ type PublicCodeV0 struct {
 	Logo            *string       `json:"logo,omitempty"            yaml:"logo,omitempty"`
 	MonochromeLogo  *string       `json:"monochromeLogo,omitempty"  yaml:"monochromeLogo,omitempty"`
 
-	Organisation *struct {
-		Name *string `json:"name,omitempty" yaml:"name,omitempty"`
-		URI  string  `json:"uri"            validate:"required,organisation_uri" yaml:"uri"`
-	} `json:"organisation,omitempty" yaml:"organisation,omitempty"`
+	Organisation *OrganisationV0 `json:"organisation,omitempty" yaml:"organisation,omitempty"`
 
 	InputTypes  *[]string `json:"inputTypes,omitempty"  validate:"omitempty,dive,is_mime_type" yaml:"inputTypes,omitempty"`
 	OutputTypes *[]string `json:"outputTypes,omitempty" validate:"omitempty,dive,is_mime_type" yaml:"outputTypes,omitempty"`
@@ -34,10 +31,7 @@ type PublicCodeV0 struct {
 
 	UsedBy *[]string `json:"usedBy,omitempty" yaml:"usedBy,omitempty"`
 
-	FundedBy *[]struct {
-		Name *string `json:"name,omitempty" yaml:"name,omitempty"`
-		URI  string  `json:"uri"            validate:"required,organisation_uri" yaml:"uri"`
-	} `json:"fundedBy,omitempty" validate:"omitempty,dive" yaml:"fundedBy,omitempty"`
+	FundedBy *[]OrganisationV0 `json:"fundedBy,omitempty" validate:"omitempty,dive" yaml:"fundedBy,omitempty"`
 
 	Roadmap *URL `json:"roadmap,omitempty" validate:"omitnil,url_http_url" yaml:"roadmap,omitempty"`
 
@@ -123,6 +117,12 @@ type DependencyV0 struct {
 	Version    *string `json:"version,omitempty"    yaml:"version,omitempty"`
 }
 
+// OrganisationV0 describes a real world organisation.
+type OrganisationV0 struct {
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	URI  string  `json:"uri"            validate:"required,organisation_uri" yaml:"uri"`
+}
+
 // Country-specific sections
 //
 // While the standard is structured to be meaningful on an international level,
@@ -157,6 +157,13 @@ func (p PublicCodeV0) Version() uint {
 }
 
 func (p PublicCodeV0) ToYAML() ([]byte, error) {
+	// Don't marshal lowercase country section.
+	// The uppercase one is always guaranteed to have the same data
+	// because we copy it for backwards compatibility
+	if p.It != nil {
+		p.It = nil
+	}
+
 	return yaml.Marshal(p)
 }
 


### PR DESCRIPTION
* Add OrganisationV0 type
* Autofill organisation.uri if it.riuso.codiceIPA. This makes things easier for consumer as the only field to check is organisation.uri
* Don't serialize it., IT. is always guaranteed to be present and have the same data as it.