### PR TITLE
fix: pass baseURL explicitly instead of storing it on Parser

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -10,12 +10,12 @@ import (
 	publiccodeValidator "github.com/italia/publiccode-parser-go/v5/validators"
 )
 
-type validateFn func(publiccode PublicCode, parser Parser, network bool) error
+type validateFn func(publiccode PublicCode, parser *Parser, network bool, baseURL *url.URL) error
 
 // validateFieldsV0 validates publiccode.yml with additional rules not validatable
 // with go-playground/validator
 // It returns any error encountered as ValidationResults.
-func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error { //nolint:maintidx
+func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseURL *url.URL) error { //nolint:maintidx
 	publiccodev0 := publiccode.(*PublicCodeV0)
 
 	var vr ValidationResults
@@ -54,7 +54,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 		if _, err := isRelativePathOrURL(*publiccodev0.Logo, "logo"); err != nil {
 			vr = append(vr, err)
 		} else if !parser.disableExternalChecks {
-			u := toAbsoluteURL(*publiccodev0.Logo, parser.currentBaseURL, network)
+			u := toAbsoluteURL(*publiccodev0.Logo, baseURL, network)
 			if u != nil {
 				validLogo, err := parser.validLogo(*u, network)
 				if !validLogo {
@@ -70,7 +70,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 		if _, err := isRelativePathOrURL(*publiccodev0.MonochromeLogo, "monochromeLogo"); err != nil {
 			vr = append(vr, err)
 		} else if !parser.disableExternalChecks {
-			u := toAbsoluteURL(*publiccodev0.MonochromeLogo, parser.currentBaseURL, network)
+			u := toAbsoluteURL(*publiccodev0.MonochromeLogo, baseURL, network)
 			if u != nil {
 				validLogo, err := parser.validLogo(*u, network)
 				if !validLogo {
@@ -117,7 +117,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 		if _, err := isRelativePathOrURL(*publiccodev0.Legal.AuthorsFile, "legal.authorsFile"); err != nil {
 			vr = append(vr, err)
 		} else if !parser.disableExternalChecks {
-			u := toAbsoluteURL(*publiccodev0.Legal.AuthorsFile, parser.currentBaseURL, network)
+			u := toAbsoluteURL(*publiccodev0.Legal.AuthorsFile, baseURL, network)
 			if u != nil {
 				exists, err := parser.fileExists(*u, network)
 				if !exists {
@@ -170,7 +170,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 			if _, err := isRelativePathOrURL(v, keyName); err != nil {
 				vr = append(vr, err)
 			} else if !parser.disableExternalChecks {
-				u := toAbsoluteURL(v, parser.currentBaseURL, network)
+				u := toAbsoluteURL(v, baseURL, network)
 				if u != nil {
 					isImage, err := parser.isImageFile(*u, network)
 					if !isImage {
@@ -245,7 +245,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 // validateFieldsV1 validates publiccode.yml with additional rules not validatable
 // with go-playground/validator
 // It returns any error encountered as ValidationResults.
-func validateFieldsV1(publiccode PublicCode, parser Parser, network bool) error {
+func validateFieldsV1(publiccode PublicCode, parser *Parser, network bool, baseURL *url.URL) error {
 	publiccodev1 := publiccode.(*PublicCodeV1)
 
 	var vr ValidationResults
@@ -284,7 +284,7 @@ func validateFieldsV1(publiccode PublicCode, parser Parser, network bool) error 
 		if _, err := isRelativePathOrURL(*publiccodev1.Logo, "logo"); err != nil {
 			vr = append(vr, err)
 		} else if !parser.disableExternalChecks {
-			u := toAbsoluteURL(*publiccodev1.Logo, parser.currentBaseURL, network)
+			u := toAbsoluteURL(*publiccodev1.Logo, baseURL, network)
 			if u != nil {
 				validLogo, err := parser.validLogo(*u, network)
 				if !validLogo {
@@ -349,7 +349,7 @@ func validateFieldsV1(publiccode PublicCode, parser Parser, network bool) error 
 			if _, err := isRelativePathOrURL(v, keyName); err != nil {
 				vr = append(vr, err)
 			} else if !parser.disableExternalChecks {
-				u := toAbsoluteURL(v, parser.currentBaseURL, network)
+				u := toAbsoluteURL(v, baseURL, network)
 				if u != nil {
 					isImage, err := parser.isImageFile(*u, network)
 					if !isImage {

--- a/parser.go
+++ b/parser.go
@@ -56,14 +56,6 @@ type Parser struct {
 	domain                Domain
 	branch                string
 	baseURL               *url.URL
-	fileURL               *url.URL
-
-	// This is the baseURL we'll try to compute and use between
-	// Parse{,Stream)() calls.
-	//
-	// XXX: It's an hack and it requires to fix the design mistake in the public API.
-	// This makes Parse{,Stream}() not thread safe.
-	currentBaseURL *url.URL
 }
 
 // Domain is a single code hosting service.
@@ -104,7 +96,38 @@ func NewDefaultParser() (*Parser, error) {
 }
 
 // ParseStream reads the data and tries to parse it. Returns an error if fails.
-func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:maintidx
+func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) {
+	return p.parseStream(in, nil)
+}
+
+func (p *Parser) Parse(uri string) (PublicCode, error) {
+	var stream io.Reader
+
+	fileURL, err := toURL(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL '%s': %w", uri, err)
+	}
+
+	if fileURL.Scheme == "file" {
+		stream, err = os.Open(fileURL.Path)
+		if err != nil {
+			return nil, fmt.Errorf("can't open file '%s': %w", fileURL.Path, err)
+		}
+	} else {
+		resp, err := http.Get(uri)
+		if err != nil {
+			return nil, fmt.Errorf("can't GET '%s': %w", uri, err)
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+
+		stream = resp.Body
+	}
+
+	return p.parseStream(stream, fileURL)
+}
+
+func (p *Parser) parseStream(in io.Reader, fileURL *url.URL) (PublicCode, error) { //nolint:maintidx
 	b, err := io.ReadAll(in)
 	if err != nil {
 		return nil, ValidationResults{newValidationErrorf("", "Can't read the stream: %v", err)}
@@ -233,26 +256,27 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:mainti
 		}
 	}
 
-	p.currentBaseURL = nil
+	// Compute the base URL for this call without mutating p (goroutine-safety).
+	var currentBaseURL *url.URL
 
 	// baseURL was not set by the user (with ParserConfig{BaseURL: "..."})),
 	// We need a base URL to perform external checks on relative files (eg. logo).
 	if p.baseURL == nil {
 		// If we parsed from an actual local or remote file, use its dir
-		if p.fileURL != nil {
-			u := *p.fileURL
+		if fileURL != nil {
+			u := *fileURL
 
-			p.currentBaseURL = &u
-			p.currentBaseURL.Path = path.Dir(p.fileURL.Path)
+			currentBaseURL = &u
+			currentBaseURL.Path = path.Dir(fileURL.Path)
 		}
 	} else {
 		u := *p.baseURL
 
-		p.currentBaseURL = &u
+		currentBaseURL = &u
 	}
 
 	// Still no base URL: we parsed from a stream, try to use the publiccode.yml's `url` field
-	if p.currentBaseURL == nil && !p.disableNetwork && publiccode.Url() != nil {
+	if currentBaseURL == nil && !p.disableNetwork && publiccode.Url() != nil {
 		rawRoot, err := vcsurl.GetRawRoot((*url.URL)(publiccode.Url()), p.branch)
 		if err != nil {
 			line, column := getPositionInFile("url", node)
@@ -269,11 +293,11 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:mainti
 			return asPublicCode(publiccode), ve
 		}
 
-		p.currentBaseURL = rawRoot
+		currentBaseURL = rawRoot
 	}
 
 	// Still no base URL: DisableNetwork is true, use the current working directory as a fallback
-	if p.currentBaseURL == nil {
+	if currentBaseURL == nil {
 		cwd, err := os.Getwd()
 		if err != nil {
 			ve = append(ve, newValidationErrorf("", "no baseURL set and failed to get working directory: %s", err))
@@ -281,10 +305,10 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:mainti
 			return asPublicCode(publiccode), ve
 		}
 
-		p.currentBaseURL = &url.URL{Scheme: "file", Path: cwd}
+		currentBaseURL = &url.URL{Scheme: "file", Path: cwd}
 	}
 
-	if err = validateFields(publiccode, *p, !p.disableNetwork); err != nil {
+	if err = validateFields(publiccode, p, !p.disableNetwork, currentBaseURL); err != nil {
 		for _, err := range err.(ValidationResults) {
 			switch err := err.(type) {
 			case ValidationError:
@@ -322,38 +346,6 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:mainti
 	}
 
 	return asPublicCode(publiccode), ve
-}
-
-func (p *Parser) Parse(uri string) (PublicCode, error) {
-	var stream io.Reader
-
-	url, err := toURL(uri)
-	if err != nil {
-		return nil, fmt.Errorf("invalid URL '%s': %w", uri, err)
-	}
-
-	p.fileURL = url
-
-	if url.Scheme == "file" {
-		stream, err = os.Open(url.Path)
-		if err != nil {
-			return nil, fmt.Errorf("can't open file '%s': %w", url.Path, err)
-		}
-	} else {
-		resp, err := http.Get(uri)
-		if err != nil {
-			return nil, fmt.Errorf("can't GET '%s': %w", uri, err)
-		}
-
-		defer func() {
-			_ = resp.Body.Close()
-			p.fileURL = nil
-		}()
-
-		stream = resp.Body
-	}
-
-	return p.ParseStream(stream)
 }
 
 // Ensure the returned value implements PublicCode as a struct, not as a pointer

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -42,6 +44,72 @@ func TestExport(t *testing.T) {
 
 	if !bytes.Equal(yaml1, yaml2) {
 		t.Errorf("Exported YAML files do not match; roundtrip is not lossless")
+	}
+}
+
+// TestParseConcurrent verifies that multiple goroutines can call Parse on the same
+// Parser instance simultaneously without data races, and that each call uses the
+// correct baseURL for its file.
+//
+// Run with "go test -race"
+func TestParseConcurrent(t *testing.T) {
+	const goroutines = 40
+
+	parser, err := NewParser(ParserConfig{DisableNetwork: true})
+	if err != nil {
+		t.Fatalf("can't create parser: %v", err)
+	}
+	// Has a logo and screenshots that only exist under no-network/assets/img/
+	fileA := "testdata/v0/valid/no-network/valid.yml"
+
+	// lives in the parent directory and has no screenshots
+	fileB := "testdata/v0/valid/categories_empty.yml"
+
+	_, errA := parser.Parse(fileA)
+	_, errB := parser.Parse(fileB)
+
+	var wg sync.WaitGroup
+
+	type result struct {
+		file string
+		err  error
+	}
+
+	results := make([]result, goroutines)
+
+	for i := range goroutines {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			file := fileA
+			if i%2 == 1 {
+				file = fileB
+			}
+
+			_, results[i].err = parser.Parse(file)
+			results[i].file = file
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, r := range results {
+		var expected error
+
+		// If base URLs leaked between goroutines, a fileA goroutine
+		// receiving fileB's baseURL would fail to locate the screenshots
+		// and return spurious validation errors.
+		if r.file == fileA {
+			expected = errA
+		} else {
+			expected = errB
+		}
+
+		if !reflect.DeepEqual(r.err, expected) {
+			t.Errorf("goroutine %d (%s): got %v, want %v", i, r.file, r.err, expected)
+		}
 	}
 }
 


### PR DESCRIPTION
Makes Parse{,Stream}() thread safe.