### PR TITLE
refactor: initialize validator and translator once at package level

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/alranel/go-vcsurl/v2"
 	urlutil "github.com/italia/publiccode-parser-go/v5/internal"
-	publiccodeValidator "github.com/italia/publiccode-parser-go/v5/validators"
 )
 
 type validateFn func(publiccode PublicCode, parser Parser, network bool) error
@@ -84,11 +83,9 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 		// This is not ideal, but we need to revalidate the countries
 		// here, because otherwise we could get a warning and the advice
 		// to use uppercase on an invalid country.
-		validate := publiccodeValidator.New()
-
 		if publiccodev0.IntendedAudience.Countries != nil {
 			for i, c := range *publiccodev0.IntendedAudience.Countries {
-				if validate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
+				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
 					vr = append(vr, ValidationWarning{
 						fmt.Sprintf("intendedAudience.countries[%d]", i),
 						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
@@ -100,7 +97,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 
 		if publiccodev0.IntendedAudience.UnsupportedCountries != nil {
 			for i, c := range *publiccodev0.IntendedAudience.UnsupportedCountries {
-				if validate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
+				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
 					vr = append(vr, ValidationWarning{
 						fmt.Sprintf("intendedAudience.unsupportedCountries[%d]", i),
 						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
@@ -220,9 +217,7 @@ func validateFieldsV0(publiccode PublicCode, parser Parser, network bool) error 
 		}
 
 		if it.Riuso.CodiceIPA != "" {
-			validate := publiccodeValidator.New()
-
-			if validate.Var(it.Riuso.CodiceIPA, "is_italian_ipa_code") == nil {
+			if sharedValidate.Var(it.Riuso.CodiceIPA, "is_italian_ipa_code") == nil {
 				vr = append(vr, ValidationWarning{
 					"IT.riuso.codiceIPA",
 					fmt.Sprintf(
@@ -298,11 +293,9 @@ func validateFieldsV1(publiccode PublicCode, parser Parser, network bool) error 
 		// This is not ideal, but we need to revalidate the countries
 		// here, because otherwise we could get a warning and the advice
 		// to use uppercase on an invalid country.
-		validate := publiccodeValidator.New()
-
 		if publiccodev1.IntendedAudience.Countries != nil {
 			for i, c := range *publiccodev1.IntendedAudience.Countries {
-				if validate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
+				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
 					vr = append(vr, ValidationWarning{
 						fmt.Sprintf("intendedAudience.countries[%d]", i),
 						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
@@ -314,7 +307,7 @@ func validateFieldsV1(publiccode PublicCode, parser Parser, network bool) error 
 
 		if publiccodev1.IntendedAudience.UnsupportedCountries != nil {
 			for i, c := range *publiccodev1.IntendedAudience.UnsupportedCountries {
-				if validate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
+				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
 					vr = append(vr, ValidationWarning{
 						fmt.Sprintf("intendedAudience.unsupportedCountries[%d]", i),
 						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),

--- a/parser.go
+++ b/parser.go
@@ -25,6 +25,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Build Validator and Translator once at package init.
+var (
+	sharedValidate *validator.Validate
+	sharedTrans    ut.Translator
+)
+
+func init() {
+	sharedValidate = publiccodeValidator.New()
+
+	enLocale := en.New()
+	uni := ut.New(enLocale, enLocale)
+
+	sharedTrans, _ = uni.GetTranslator("en")
+	_ = en_translations.RegisterDefaultTranslations(sharedValidate, sharedTrans)
+	_ = publiccodeValidator.RegisterLocalErrorMessages(sharedValidate, sharedTrans)
+}
+
 type ParserConfig struct {
 	// DisableNetwork disables all network tests (eg. URL existence). This
 	// results in much faster parsing.
@@ -196,22 +213,9 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:mainti
 		ve = append(ve, decodeResults...)
 	}
 
-	validate := publiccodeValidator.New()
-
-	en := en.New()
-	uni := ut.New(en, en)
-
-	trans, _ := uni.GetTranslator("en")
-	_ = en_translations.RegisterDefaultTranslations(validate, trans)
-	_ = publiccodeValidator.RegisterLocalErrorMessages(validate, trans)
-
-	err = validate.Struct(publiccode)
+	err = sharedValidate.Struct(publiccode)
 	if err != nil {
 		for _, err := range err.(validator.ValidationErrors) {
-			var sb strings.Builder
-
-			sb.WriteString(err.Translate(trans))
-
 			// TODO: find a cleaner way
 			key := strings.Replace(
 				err.Namespace(),
@@ -226,7 +230,7 @@ func (p *Parser) ParseStream(in io.Reader) (PublicCode, error) { //nolint:mainti
 
 			ve = append(ve, ValidationError{
 				Key:         key,
-				Description: sb.String(),
+				Description: err.Translate(sharedTrans),
 				Line:        line,
 				Column:      column,
 			})


### PR DESCRIPTION
The validator is thread safe and expensive to create (it registers all custom validators and translations).

Build it once at package initialization.