### PR TITLE
feat: add configurable HTTP timeout to ParserConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.18.0
-	github.com/italia/httpclient-lib-go v0.0.2
+	github.com/italia/httpclient-lib-go v0.0.3-0.20260316100201-5dd490bc4896
 	github.com/rivo/uniseg v0.4.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/go-playground/validator/v10 v10.18.0 h1:BvolUXjp4zuvkZ5YN5t7ebzbhlUtP
 github.com/go-playground/validator/v10 v10.18.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/italia/httpclient-lib-go v0.0.2 h1:4bJLywTVd7qHPdKxJXvvhlXp436JTC4KA6dLhIl5a6c=
 github.com/italia/httpclient-lib-go v0.0.2/go.mod h1:b0/D3ULsBw8X+zEl7j/kSZmiMlUdj+agppneOvSq6eA=
+github.com/italia/httpclient-lib-go v0.0.3-0.20260316100201-5dd490bc4896 h1:7JV5L0I++QbIMdVjU467tUW+dQnX6hdmhMLZAjrehjQ=
+github.com/italia/httpclient-lib-go v0.0.3-0.20260316100201-5dd490bc4896/go.mod h1:b0/D3ULsBw8X+zEl7j/kSZmiMlUdj+agppneOvSq6eA=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/internal/netutil.go
+++ b/internal/netutil.go
@@ -13,7 +13,7 @@ import (
 )
 
 // downloadFile download the file in the path.
-func downloadFile(filepath string, url *url.URL, headers map[string]string) error {
+func downloadFile(client *httpclient.Client, filepath string, url *url.URL, headers map[string]string) error {
 	// Create the file.
 	out, err := os.Create(filepath)
 	if err != nil {
@@ -25,7 +25,7 @@ func downloadFile(filepath string, url *url.URL, headers map[string]string) erro
 	}()
 
 	// Get the data from the url.
-	resp, err := httpclient.GetURL(url.String(), headers)
+	resp, err := client.GetURL(url.String(), headers)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func downloadFile(filepath string, url *url.URL, headers map[string]string) erro
 
 // DownloadTmpFile downloads the passed URL to a temporary directory.
 // Caller is responsible for removing the temporary directory.
-func DownloadTmpFile(url *url.URL, headers map[string]string) (string, error) {
+func DownloadTmpFile(client *httpclient.Client, url *url.URL, headers map[string]string) (string, error) {
 	// Create a temp dir
 	tmpdir, err := os.MkdirTemp("", "publiccode.yml-parser-go")
 	if err != nil {
@@ -50,7 +50,7 @@ func DownloadTmpFile(url *url.URL, headers map[string]string) (string, error) {
 	// Download the file in the temp dir.
 	tmpFile := filepath.Join(tmpdir, path.Base(url.Path))
 
-	err = downloadFile(tmpFile, url, headers)
+	err = downloadFile(client, tmpFile, url, headers)
 	if err != nil {
 		return "", err
 	}

--- a/parser.go
+++ b/parser.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/alranel/go-vcsurl/v2"
@@ -20,6 +21,7 @@ import (
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
+	httpclient "github.com/italia/httpclient-lib-go"
 	urlutil "github.com/italia/publiccode-parser-go/v5/internal"
 	publiccodeValidator "github.com/italia/publiccode-parser-go/v5/validators"
 	"gopkg.in/yaml.v3"
@@ -64,7 +66,13 @@ type ParserConfig struct {
 	// The URL used as base of relative files in publiccode.yml (eg. logo)
 	// It can be a local file with the 'file' scheme.
 	BaseURL string
+
+	// Timeout is the maximum duration for each HTTP request during external checks.
+	// Defaults to 30s if zero.
+	Timeout time.Duration
 }
+
+const defaultHTTPTimeout = 30 * time.Second
 
 // Parser is a helper class for parsing publiccode.yml files.
 type Parser struct {
@@ -73,6 +81,8 @@ type Parser struct {
 	domain                Domain
 	branch                string
 	baseURL               *url.URL
+	client                *http.Client
+	httpclient            *httpclient.Client
 }
 
 // Domain is a single code hosting service.
@@ -90,11 +100,19 @@ func NewParser(config ParserConfig) (*Parser, error) {
 		config.DisableNetwork = true
 	}
 
+	timeout := config.Timeout
+	if timeout == 0 {
+		timeout = defaultHTTPTimeout
+	}
+
+	httpClient := &http.Client{Timeout: timeout}
 	parser := Parser{
 		disableNetwork:        config.DisableNetwork,
 		disableExternalChecks: config.DisableExternalChecks,
 		domain:                config.Domain,
 		branch:                config.Branch,
+		client:                httpClient,
+		httpclient:            httpclient.NewClient(httpClient),
 	}
 
 	if config.BaseURL != "" {
@@ -131,7 +149,7 @@ func (p *Parser) Parse(uri string) (PublicCode, error) {
 			return nil, fmt.Errorf("can't open file '%s': %w", fileURL.Path, err)
 		}
 	} else {
-		resp, err := http.Get(uri)
+		resp, err := p.client.Get(uri)
 		if err != nil {
 			return nil, fmt.Errorf("can't GET '%s': %w", uri, err)
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,10 +3,15 @@ package publiccode
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // Test that the exported YAML passes validation again, and that re-exporting it
@@ -110,6 +115,90 @@ func TestParseConcurrent(t *testing.T) {
 		if !reflect.DeepEqual(r.err, expected) {
 			t.Errorf("goroutine %d (%s): got %v, want %v", i, r.file, r.err, expected)
 		}
+	}
+}
+
+// TestDefaultTimeout checks that the default HTTP timeout is set when
+// ParserConfig.Timeout is zero.
+func TestDefaultTimeout(t *testing.T) {
+	p, err := NewParser(ParserConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p.client.Timeout != defaultHTTPTimeout {
+		t.Errorf("expected default timeout %v, got %v", defaultHTTPTimeout, p.client.Timeout)
+	}
+}
+
+// TestParseTimeout checks that Parse() fails when the server exceeds the
+// configured timeout while fetching the publiccode.yml itself.
+func TestParseTimeout(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/v0/valid/valid.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/yaml")
+		w.Write(fixture) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	p, err := NewParser(ParserConfig{Timeout: 1 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Parse(srv.URL + "/publiccode.yml")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+}
+
+// TestValidationTimeout checks that external validation checks (logo) fail when
+// the server exceeds the configured timeout.
+func TestValidationTimeout(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer slow.Close()
+
+	// Read logo_with_url.yml and redirect its logo to the slow server.
+	fixture, err := os.ReadFile("testdata/v0/valid/logo_with_url.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	yml := bytes.ReplaceAll(fixture,
+		[]byte("https://raw.githubusercontent.com/italia/publiccode-parser-go/refs/heads/main/testdata/v0/valid/assets/img/logo.png"),
+		[]byte(slow.URL+"/logo.png"),
+	)
+
+	fast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml")
+		w.Write(yml) //nolint:errcheck
+	}))
+	defer fast.Close()
+
+	p, err := NewParser(ParserConfig{Timeout: 1 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Parse(fast.URL + "/publiccode.yml")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected timeout error, got: %v", err)
 	}
 }
 

--- a/validations.go
+++ b/validations.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/alranel/go-vcsurl/v2"
 	"github.com/dyatlov/go-oembed/oembed"
-	httpclient "github.com/italia/httpclient-lib-go"
 	"github.com/italia/publiccode-parser-go/v5/data"
 	netutil "github.com/italia/publiccode-parser-go/v5/internal"
 )
@@ -69,7 +68,7 @@ func (p *Parser) isReachable(u url.URL) (bool, error) {
 		return false, fmt.Errorf("missing URL scheme")
 	}
 
-	r, err := httpclient.GetURL(u.String(), getHeaderFromDomain(p.domain, u.String()))
+	r, err := p.httpclient.GetURL(u.String(), getHeaderFromDomain(p.domain, u.String()))
 	if err != nil {
 		return false, fmt.Errorf("HTTP GET failed for %s: %v", u.String(), err)
 	}
@@ -174,7 +173,7 @@ func (p *Parser) validLogo(u url.URL, network bool) (bool, error) {
 			return true, nil
 		}
 
-		localPath, err = netutil.DownloadTmpFile(&u, getHeaderFromDomain(p.domain, u.String()))
+		localPath, err = netutil.DownloadTmpFile(p.httpclient, &u, getHeaderFromDomain(p.domain, u.String()))
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Add ParserConfig.Timeout so external checks don't hang the validation forever.

Fix #282.