### PR TITLE
fix: accept 4-8 char primary language subtags per RFC 5646 §2.1

### DIFF
--- a/validators/bcp47.go
+++ b/validators/bcp47.go
@@ -117,9 +117,12 @@ func isValidBCP47StrictLanguageTag(s string) bool {
 			return false
 		}
 	case n == 4:
-		return false
+		// 4-alpha primary subtags are reserved for future use per RFC 5646 §2.1;
+		// accept them syntactically even though none are currently assigned.
 	default:
-		return false
+		// 5-8 alpha: registered language subtag per RFC 5646 §2.1.
+		// golang.org/x/text/language does not cover these, so syntactic
+		// validation by the regex above is sufficient.
 	}
 
 	if script != "" {

--- a/validators/bcp47_test.go
+++ b/validators/bcp47_test.go
@@ -1,0 +1,94 @@
+package validators
+
+import (
+	"testing"
+)
+
+func TestIsValidBCP47StrictLanguageTag(t *testing.T) {
+	tests := []struct {
+		tag   string
+		valid bool
+	}{
+		// 2-char primary subtags (ISO 639-1)
+		{"en", true},
+		{"it", true},
+		{"fr", true},
+		{"de", true},
+
+		// 3-char primary subtags with no ISO 639-1 2-char equivalent —
+		// these normalize to themselves in golang.org/x/text/language.
+		// 3-char codes that do have a 2-char form (e.g. "eng"→"en") are
+		// rejected because the validator requires the canonical form.
+		{"sgn", true},
+		{"tlh", true},
+		{"jbo", true},
+
+		// 5-8 char primary subtags (RFC 5646 §2.1 registered language subtag).
+		// Were incorrectly rejected before this fix.
+		{"abcde", true},    // 5 chars
+		{"abcdefg", true},  // 7 chars
+		{"abcdefgh", true}, // 8 chars
+
+		// 4-char primary subtag (reserved for future use per RFC 5646 §2.1)
+		{"abcd", true},
+
+		// With region subtag
+		{"en-US", true},
+		{"it-IT", true},
+		{"en-GB", true},
+		{"zh-CN", true},
+
+		// With script subtag
+		{"zh-Hant", true},
+		{"zh-Hans", true},
+		{"sr-Latn", true},
+
+		// With script and region
+		{"zh-Hant-TW", true},
+		{"sr-Latn-RS", true},
+
+		// With extlang subtag
+		{"zh-cmn", true},
+
+		// Grandfathered irregular tags
+		{"i-ami", true},
+		{"i-bnn", true},
+		{"art-lojban", true},
+		{"zh-min", true},
+
+		// Private use
+		{"x-private", true},
+		{"x-12345678", true},
+
+		// Empty string
+		{"", false},
+
+		// POSIX-style (underscore separator)
+		{"en_US", false},
+		{"en_GB", false},
+
+		// Primary subtag too long (> 8 chars)
+		{"abcdefghi", false},
+
+		// Digits in primary subtag position
+		{"1234", false},
+
+		// 3-char code with a 2-char canonical form: requires canonical "en"
+		{"eng", false},
+
+		// Unknown extlang subtag
+		{"en-xyz", false},
+
+		// Invalid region
+		{"en-ZZZ", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			got := isValidBCP47StrictLanguageTag(tt.tag)
+			if got != tt.valid {
+				t.Errorf("isValidBCP47StrictLanguageTag(%q) = %v, want %v", tt.tag, got, tt.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`isValidBCP47StrictLanguageTag` rejected 4-8 char primary language subtags because of two dead-end switch cases:

```go
case n == 4:
    return false
default:
    return false  // 5-8 chars land here
```

RFC 5646 §2.1 allows three forms for the primary language subtag beyond the usual 2-3 alpha ISO 639 codes:
- 4 alpha — reserved for future use
- 5-8 alpha — registered language subtag

The regex (group 2) already accepts `[A-Z]{4}` and `[A-Z]{5,8}`, so these tags passed syntactic validation only to be rejected by the switch. `golang.org/x/text/language` does not cover 4-8 char primary subtags, so the regex check is sufficient.

Also adds a unit test suite for `isValidBCP47StrictLanguageTag` — previously untested directly.