### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 1 * * 1"
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds the OpenSSF Scorecard workflow to continuously evaluate the project's supply chain security posture.

Runs weekly (Monday 01:30 UTC) and on every push to `main`. The action checks ~20 criteria including branch protection, pinned dependencies, CI test coverage, signed releases, vulnerability disclosure policy, and more.

Results are:
- Published to the public dashboard at https://scorecard.dev/viewer/?uri=github.com/italia/publiccode-parser-go
- Uploaded as SARIF to the GitHub Security tab (requires Advanced Security — free for public repos)

The `publish_results: true` setting and `id-token: write` permission are needed to push to the public Scorecard API. If you prefer to keep results private, set `publish_results: false` and drop `id-token: write`.