### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security vulnerabilities via [GitHub private vulnerability reporting](https://github.com/italia/publiccode-parser-go/security/advisories/new).
+
+Do not open a public issue.


### PR DESCRIPTION
No SECURITY.md means GitHub does not surface a disclosure path in the Security tab, and reporters default to opening public issues.

Points to GitHub private vulnerability reporting so reports stay confidential until a fix is ready.