### PR TITLE
fix: use latestVersion in outdated version warning message

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -256,8 +256,9 @@ func (p *Parser) parseStream(in io.Reader, fileURL *url.URL) (PublicCode, error)
 		ve = append(ve, ValidationWarning{
 			Key: "publiccodeYmlVersion",
 			Description: fmt.Sprintf(
-				"v%s is not the latest version, use '0'. Parsing this file as v%s.",
+				"v%s is not the latest version, use '%s'. Parsing this file as v%s.",
 				version,
+				latestVersion,
 				latestVersion,
 			),
 			Line:   line,

--- a/v0_test.go
+++ b/v0_test.go
@@ -604,13 +604,13 @@ func TestValidWithWarningsTestcasesV0(t *testing.T) {
 			ValidationWarning{"description.en.genericName", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 23, 5},
 		},
 		"valid.minimal.v0.2.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.2 is not the latest version, use '0'. Parsing this file as v0.5.", 1, 1},
+			ValidationWarning{"publiccodeYmlVersion", "v0.2 is not the latest version, use '0.5'. Parsing this file as v0.5.", 1, 1},
 		},
 		"valid.minimal.v0.3.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.3 is not the latest version, use '0'. Parsing this file as v0.5.", 1, 1},
+			ValidationWarning{"publiccodeYmlVersion", "v0.3 is not the latest version, use '0.5'. Parsing this file as v0.5.", 1, 1},
 		},
 		"valid.minimal.v0.4.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.4 is not the latest version, use '0'. Parsing this file as v0.5.", 1, 1},
+			ValidationWarning{"publiccodeYmlVersion", "v0.4 is not the latest version, use '0.5'. Parsing this file as v0.5.", 1, 1},
 		},
 		"valid.mime_types.yml": ValidationResults{
 			ValidationWarning{"inputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 48, 1},


### PR DESCRIPTION
The warning shown when parsing an old publiccode.yml version hard-codes `'0'` in the message string instead of using the `latestVersion` variable computed on the line above:

```go
latestVersion := SupportedVersions[len(SupportedVersions)-1]  // "0.5"
// ...
"v%s is not the latest version, use '0'. Parsing this file as v%s."
//                                 ^^^
//                          should be latestVersion
```

Users parsing a v0.3 file see: `"use '0'"` instead of `"use '0.5'"`.