### PR TITLE
ci: sync ipa codes weekly from italian-organizations-ipa-vocabulary

### DIFF
--- a/.github/workflows/file-freshness-pr.yml
+++ b/.github/workflows/file-freshness-pr.yml
@@ -2,7 +2,7 @@ name: Update external files
 on:
   workflow_dispatch:
   schedule:
-    - cron: 15 8 * * *
+    - cron: 15 8 * * 1
 
 permissions: {}
 
@@ -13,11 +13,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - run: >
-          curl -sL 'https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt'
-          | tail -n +2
-          | cut -f1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Sync IPA codes from vocabulary repo
+        run: >
+          curl -sL 'https://raw.githubusercontent.com/publiccodeyml/italian-organizations-ipa-vocabulary/main/ipa-codes.txt'
+          | sed 's|^urn:x-italian-pa:||'
           | LC_COLLATE=C sort > data/it/ipa_codes.txt
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:


### PR DESCRIPTION
Fixes the daily PR churn caused by downloading directly from Agid.

Instead of pulling from indicepa.gov.it every day, the workflow now syncs
weekly (Monday 08:15) from publiccodeyml/italian-organizations-ipa-vocabulary,
which already handles the daily fetch and auto-commits.

The vocabulary repo stores codes as `urn:x-italian-pa:XXXX` — the workflow
strips the prefix before writing to data/it/ipa_codes.txt so the embedded
format stays unchanged.

Related: #348.