### PR TITLE
fix: avoid allocating a new validator on every isOrganisationURI call

### DIFF
--- a/v0_test.go
+++ b/v0_test.go
@@ -238,7 +238,7 @@ func TestInvalidTestcasesV0(t *testing.T) {
 			ValidationError{"organisation.uri", "uri is not a valid URI", 20, 3},
 		},
 		"organisation_uri_wrong_italian_pa2.yml": ValidationResults{
-			ValidationError{"organisation.uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt)", 19, 3},
+			ValidationError{"organisation.uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 19, 3},
 		},
 
 		// inputTypes
@@ -288,7 +288,7 @@ func TestInvalidTestcasesV0(t *testing.T) {
 			ValidationError{"fundedBy[0].uri", "uri is not a valid URI", 20, 5},
 		},
 		"fundedBy_uri_wrong_italian_pa2.yml": ValidationResults{
-			ValidationError{"fundedBy[0].uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt)", 19, 5},
+			ValidationError{"fundedBy[0].uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 19, 5},
 		},
 
 		// roadmap
@@ -535,7 +535,7 @@ func TestInvalidTestcasesV0(t *testing.T) {
 			ValidationError{"IT.countryExtensionVersion", "countryExtensionVersion must be one of the following: \"0.2\" or \"1.0\"", 12, 3},
 		},
 		"it_riuso_codiceIPA_invalid.yml": ValidationResults{
-			ValidationError{"IT.riuso.codiceIPA", "codiceIPA must be a valid Italian Public Administration Code (iPA) (see https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt)", 55, 5},
+			ValidationError{"IT.riuso.codiceIPA", "codiceIPA must be a valid Italian Public Administration Code (iPA) (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 55, 5},
 		},
 		"it_IT_duplicated.yml": ValidationResults{
 			ValidationWarning{"it", "Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead", 116, 1},

--- a/validators/common.go
+++ b/validators/common.go
@@ -81,8 +81,6 @@ func isURL(fl validator.FieldLevel) bool {
 }
 
 func isOrganisationURI(fl validator.FieldLevel) bool {
-	validate := New()
-
 	field := fl.Field().String()
 
 	u, err := url.ParseRequestURI(field)
@@ -92,16 +90,17 @@ func isOrganisationURI(fl validator.FieldLevel) bool {
 
 	// Validate URNs as well
 	if strings.EqualFold(u.Scheme, "urn") {
-		err := validate.Var(field, "urn_rfc2141")
+		err := sharedValidator.Var(field, "urn_rfc2141")
 		if err != nil {
 			return false
 		}
 
 		if strings.HasPrefix(strings.ToLower(u.Opaque), "x-italian-pa:") {
 			ipa := u.Opaque[len("x-italian-pa:"):]
-			err := validate.Var(ipa, "is_italian_ipa_code")
 
-			return err == nil
+			_, ok := ipaCodes[strings.ToLower(ipa)]
+
+			return ok
 		}
 
 		return true

--- a/validators/it.go
+++ b/validators/it.go
@@ -20,8 +20,8 @@ func init() {
 	}
 }
 
-// isCodiceIPA returns true if the field is a valid Italian Public Administration Code
-// (iPA) from https://indicepa.gov.it.
+// isItalianIpaCode returns true if the field is a valid Italian Public Administration Code
+// (iPA) from https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary.
 func isItalianIpaCode(fl validator.FieldLevel) bool {
 	_, ok := ipaCodes[strings.ToLower(fl.Field().String())]
 

--- a/validators/validator.go
+++ b/validators/validator.go
@@ -155,7 +155,7 @@ func RegisterLocalErrorMessages(v *validator.Validate, trans ut.Translator) erro
 
 				err = ut.Add(
 					"organisation_uri_invalid_italian_pa",
-					"{0} must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt)", //nolint:lll // long URL in message
+					"{0} must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", //nolint:lll // long URL in message
 					false)
 				if err != nil {
 					return fmt.Errorf("registering translation: %w", err)
@@ -200,7 +200,7 @@ func RegisterLocalErrorMessages(v *validator.Validate, trans ut.Translator) erro
 		},
 		{
 			tag:         "is_italian_ipa_code",
-			translation: "{0} must be a valid Italian Public Administration Code (iPA) (see https://www.indicepa.gov.it/public-services/opendata-read-service.php?dstype=FS&filename=amministrazioni.txt)", //nolint:lll // long URL in message
+			translation: "{0} must be a valid Italian Public Administration Code (iPA) (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", //nolint:lll // long URL in message
 		},
 		{
 			tag:         "iso3166_1_alpha2_lower_or_upper",


### PR DESCRIPTION
`isOrganisationURI` called `New()` on each invocation, re-registering all
custom validators for every field being validated. Fix: use the existing
`sharedValidator` for `urn_rfc2141` (built-in) and a direct map lookup
on `ipaCodes` for the IPA code check (same package).

Also updates two stale error message URLs that still pointed to the
old IndicePA open data feed instead of the vocabulary repo.