### PR TITLE
feat: support publiccode.yml 0.7

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -249,7 +249,7 @@ func (p *Parser) parseStream(in io.Reader, fileURL *url.URL) (PublicCode, error)
 
 	var ve ValidationResults
 
-	if slices.Contains(SupportedVersions, version) && version != "0" && !strings.HasPrefix(version, "0.5") {
+	if slices.Contains(SupportedVersions, version) && version != "0" && !strings.HasPrefix(version, "0.7") {
 		latestVersion := SupportedVersions[len(SupportedVersions)-1]
 		line, column := getPositionInFile("publiccodeYmlVersion", file)
 

--- a/publiccode.go
+++ b/publiccode.go
@@ -1,7 +1,14 @@
 package publiccode
 
 // SupportedVersions lists the publiccode.yml versions this parser supports.
-var SupportedVersions = []string{"0", "0.2", "0.2.0", "0.2.1", "0.2.2", "0.3", "0.3.0", "0.4", "0.4.0", "0.5.0", "0.5"}
+var SupportedVersions = []string{
+	"0",
+	"0.2", "0.2.0", "0.2.1", "0.2.2",
+	"0.3", "0.3.0",
+	"0.4", "0.4.0",
+	"0.5.0", "0.5",
+	"0.7.0", "0.7",
+}
 
 type PublicCode interface {
 	Version() uint

--- a/testdata/v0/invalid/no-network/supports_unknown_alias.yml
+++ b/testdata/v0/invalid/no-network/supports_unknown_alias.yml
@@ -1,0 +1,53 @@
+publiccodeYmlVersion: "0"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone/other"
+
+supports:
+  - id: alias:nonexistent
+
+description:
+  en-GB:
+    localisedName: Medusa
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  license: AGPL-3.0-or-later
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en

--- a/testdata/v0/valid/no-network/valid_with_supports.yml
+++ b/testdata/v0/valid/no-network/valid_with_supports.yml
@@ -1,0 +1,56 @@
+publiccodeYmlVersion: "0"
+
+name: Medusa
+url: "https://github.com/italia/developers.italia.it.git"
+
+platforms:
+  - web
+
+categories:
+  - cloud-management
+
+developmentStatus: development
+
+softwareType: "standalone/other"
+
+supports:
+  - id: alias:gdpr
+  - id: alias:spid
+  - id: "https://eur-lex.europa.eu/eli/reg/2016/679/oj"
+  - id: "urn:iso:std:iso:27001"
+
+description:
+  en-GB:
+    localisedName: Medusa
+    shortDescription: >
+          A rather short description which
+          is probably useless
+    longDescription: >
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 158 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 316 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 474 characters.
+          Very long description of this software, also split
+          on multiple rows. You should note what the software
+          is and why one should need it. This is 632 characters.
+    features:
+       - Just one feature
+
+legal:
+  license: AGPL-3.0-or-later
+
+maintenance:
+  type: "community"
+
+  contacts:
+    - name: Francesco Rossi
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - en

--- a/v0.go
+++ b/v0.go
@@ -9,7 +9,7 @@ import (
 
 // PublicCodeV0 defines how a publiccode.yml v0.x is structured.
 type PublicCodeV0 struct {
-	PubliccodeYamlVersion string `json:"publiccodeYmlVersion" validate:"required,oneof=0 0.2 0.2.0 0.2.1 0.2.2 0.3 0.3.0 0.4 0.4.0 0.5 0.5.0" yaml:"publiccodeYmlVersion"`
+	PubliccodeYamlVersion string `json:"publiccodeYmlVersion" validate:"required,oneof=0 0.2 0.2.0 0.2.1 0.2.2 0.3 0.3.0 0.4 0.4.0 0.5 0.5.0 0.7 0.7.0" yaml:"publiccodeYmlVersion"`
 
 	Name             string `json:"name"                       validate:"required"               yaml:"name"`
 	ApplicationSuite string `json:"applicationSuite,omitempty" yaml:"applicationSuite,omitempty"`
@@ -40,6 +40,8 @@ type PublicCodeV0 struct {
 	DevelopmentStatus string `json:"developmentStatus" validate:"required,oneof=concept development beta stable obsolete" yaml:"developmentStatus"`
 
 	SoftwareType string `json:"softwareType" validate:"required,oneof=standalone/mobile standalone/iot standalone/desktop standalone/web standalone/backend standalone/other addon library configurationFiles" yaml:"softwareType"`
+
+	Supports *[]SupportV0 `json:"supports,omitempty" validate:"omitempty,dive" yaml:"supports,omitempty"`
 
 	IntendedAudience *struct {
 		Scope                *[]string `json:"scope,omitempty"                validate:"omitempty,dive,is_scope_v0"                     yaml:"scope,omitempty"`
@@ -123,6 +125,12 @@ type DependencyV0 struct {
 type OrganisationV0 struct {
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 	URI  string  `json:"uri"            validate:"required,organisation_uri" yaml:"uri"`
+}
+
+// SupportV0 declares a standard, regulation, framework or system the
+// software supports or complies with.
+type SupportV0 struct {
+	ID string `json:"id" validate:"required,supports_id" yaml:"id"`
 }
 
 // Country-specific sections

--- a/v0_test.go
+++ b/v0_test.go
@@ -81,6 +81,11 @@ func TestInvalidTestcasesV0_NoNetwork(t *testing.T) {
 			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 51, 3},
 			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
 		},
+
+		// supports
+		"supports_unknown_alias.yml": ValidationResults{
+			ValidationError{"supports[0].id", "id contains an unknown alias (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/aliases-list.rst)", 17, 5},
+		},
 	}
 
 	dir := "testdata/v0/invalid/no-network/"
@@ -110,7 +115,7 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		"publiccodeYmlVersion_invalid.yml": ValidationResults{
 			ValidationError{
 				"publiccodeYmlVersion",
-				"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0, 0.5.0, 0.5",
+				"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0, 0.5.0, 0.5, 0.7.0, 0.7",
 				0,
 				0,
 			},
@@ -604,13 +609,13 @@ func TestValidWithWarningsTestcasesV0(t *testing.T) {
 			ValidationWarning{"description.en.genericName", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 23, 5},
 		},
 		"valid.minimal.v0.2.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.2 is not the latest version, use '0'. Parsing this file as v0.5.", 1, 1},
+			ValidationWarning{"publiccodeYmlVersion", "v0.2 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
 		},
 		"valid.minimal.v0.3.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.3 is not the latest version, use '0'. Parsing this file as v0.5.", 1, 1},
+			ValidationWarning{"publiccodeYmlVersion", "v0.3 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
 		},
 		"valid.minimal.v0.4.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.4 is not the latest version, use '0'. Parsing this file as v0.5.", 1, 1},
+			ValidationWarning{"publiccodeYmlVersion", "v0.4 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
 		},
 		"valid.mime_types.yml": ValidationResults{
 			ValidationWarning{"inputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 48, 1},

--- a/v1_test.go
+++ b/v1_test.go
@@ -14,7 +14,7 @@ func TestInvalidTestcasesV1(t *testing.T) {
 	expected := ValidationResults{
 		ValidationError{
 			"publiccodeYmlVersion",
-			"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0, 0.5.0, 0.5",
+			"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0, 0.5.0, 0.5, 0.7.0, 0.7",
 			0,
 			0,
 		},

--- a/validators/v0.go
+++ b/validators/v0.go
@@ -1,6 +1,11 @@
 package validators
 
-import "github.com/go-playground/validator/v10"
+import (
+	"net/url"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
 
 var supportedCategoriesV0 = map[string]struct{}{
 	"accounting":                      {},
@@ -138,6 +143,18 @@ var supportedScopesV0 = map[string]struct{}{
 	"welfare":                          {},
 }
 
+var supportsAliasesV0 = map[string]struct{}{
+	"gdpr":   {},
+	"eidas":  {},
+	"nis2":   {},
+	"cra":    {},
+	"spid":   {},
+	"cie":    {},
+	"anpr":   {},
+	"pagopa": {},
+	"io":     {},
+}
+
 func isCategoryV0(fl validator.FieldLevel) bool {
 	_, ok := supportedCategoriesV0[fl.Field().String()]
 
@@ -148,4 +165,28 @@ func isScopeV0(fl validator.FieldLevel) bool {
 	_, ok := supportedScopesV0[fl.Field().String()]
 
 	return ok
+}
+
+// isSupportsID validates a supports[].id: either an alias in the form
+// alias:<name> that must exist in the alias list, or any other valid URI
+// (URL or URN).
+func isSupportsID(fl validator.FieldLevel) bool {
+	val := fl.Field().String()
+
+	if alias, ok := strings.CutPrefix(val, "alias:"); ok {
+		_, known := supportsAliasesV0[alias]
+
+		return known
+	}
+
+	u, err := url.ParseRequestURI(val)
+	if err != nil {
+		return false
+	}
+
+	if strings.EqualFold(u.Scheme, "urn") {
+		return sharedValidator.Var(val, "urn_rfc2141") == nil
+	}
+
+	return u.Scheme != "" && u.Host != ""
 }

--- a/validators/validator.go
+++ b/validators/validator.go
@@ -23,6 +23,8 @@ func New() *validator.Validate {
 	_ = validate.RegisterValidation("is_category_v0", isCategoryV0)
 	_ = validate.RegisterValidation("is_scope_v0", isScopeV0)
 
+	_ = validate.RegisterValidation("supports_id", isSupportsID)
+
 	_ = validate.RegisterValidation("is_italian_ipa_code", isItalianIpaCode)
 
 	_ = validate.RegisterValidation("bcp47_keys", bcp47_keys)
@@ -197,6 +199,42 @@ func RegisterLocalErrorMessages(v *validator.Validate, trans ut.Translator) erro
 		{
 			tag:         "is_scope_v0",
 			translation: "{0} must be a valid scope (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/scope-list.rst)", //nolint:lll // long URL in message
+		},
+		{
+			tag: "supports_id",
+			customRegisFunc: func(ut ut.Translator) error {
+				if err := ut.Add(
+					"supports_id",
+					"{0} must be a known alias ('alias:<name>') or a valid URI (URL or URN)",
+					false,
+				); err != nil {
+					return fmt.Errorf("registering translation: %w", err)
+				}
+
+				if err := ut.Add(
+					"supports_id_unknown_alias",
+					"{0} contains an unknown alias (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/aliases-list.rst)", //nolint:lll // long URL in message
+					false,
+				); err != nil {
+					return fmt.Errorf("registering translation: %w", err)
+				}
+
+				return nil
+			},
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				field := fe.Field()
+				val, _ := fe.Value().(string)
+
+				if strings.HasPrefix(val, "alias:") {
+					t, _ := ut.T("supports_id_unknown_alias", field)
+
+					return t
+				}
+
+				t, _ := ut.T("supports_id", field)
+
+				return t
+			},
 		},
 		{
 			tag:         "is_italian_ipa_code",


### PR DESCRIPTION
`0.7` adds a generic `supports` key to declare the standards, regulations or platforms a software complies with. id is either an alias from the documented list or a plain URI.

See https://github.com/publiccodeyml/publiccode.yml/discussions/327