### PR TITLE
Harden HTTP client against SSRF and unbounded downloads

### DIFF
--- a/fields_v1_test.go
+++ b/fields_v1_test.go
@@ -156,7 +156,7 @@ func TestValidateFieldsV1WithNetworkChecks(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, _ := NewParser(ParserConfig{DisableNetwork: false, DisableExternalChecks: false})
+	p, _ := NewParser(ParserConfig{DisableNetwork: false, DisableExternalChecks: false, AllowNetworkToPrivateHosts: true})
 	base := &url.URL{Scheme: "file", Path: "/tmp"}
 
 	// srv.URL is not a code repo, so IsRepo should return false
@@ -202,7 +202,7 @@ func TestValidateFieldsV1WithUnreachableURLs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, _ := NewParser(ParserConfig{DisableNetwork: false, DisableExternalChecks: false})
+	p, _ := NewParser(ParserConfig{DisableNetwork: false, DisableExternalChecks: false, AllowNetworkToPrivateHosts: true})
 	base := &url.URL{Scheme: "file", Path: "/tmp"}
 
 	rawURL, _ := url.Parse(srv.URL + "/repo.git")
@@ -241,7 +241,7 @@ func TestValidateFieldsV1WithAPIDocNetworkCheck(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, _ := NewParser(ParserConfig{})
+	p, _ := NewParser(ParserConfig{AllowNetworkToPrivateHosts: true})
 	base := &url.URL{Scheme: "file", Path: "/tmp"}
 
 	apiDocRaw, _ := url.Parse(srv.URL + "/api-docs")

--- a/internal/safehttp.go
+++ b/internal/safehttp.go
@@ -1,0 +1,152 @@
+package netutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// MaxResponseBytes caps how many bytes the parser reads from a single remote
+// resource. Without a cap an attacker-controlled URL in a publiccode.yml could
+// point at an endless or huge response and exhaust the memory/disk of the host
+// running the parser (e.g. the publiccode-crawler).
+const MaxResponseBytes int64 = 20 << 20 // 20 MiB
+
+// ErrBlockedAddress is returned when a request would connect to a non-public
+// (loopback, private, link-local, ...) address. It protects against SSRF where
+// a URL in an untrusted publiccode.yml is used to reach internal services or
+// cloud metadata endpoints.
+var ErrBlockedAddress = errors.New("blocked attempt to connect to a non-public address")
+
+// ErrResponseTooLarge is returned when a remote response exceeds MaxResponseBytes.
+var ErrResponseTooLarge = fmt.Errorf("response body exceeds the maximum allowed size of %d bytes", MaxResponseBytes)
+
+// isPublicIP reports whether ip is a globally routable address the parser is
+// allowed to reach. Loopback, unspecified, private (RFC 1918 / RFC 4193),
+// link-local (incl. the 169.254.169.254 cloud metadata address), CGNAT and
+// multicast ranges are refused.
+func isPublicIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() ||
+		ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+
+	// 100.64.0.0/10 (CGNAT, RFC 6598) is not covered by IsPrivate().
+	if ip4 := ip.To4(); ip4 != nil {
+		if ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// newDialControl returns a net.Dialer Control function that rejects connections
+// to non-public addresses. It runs after DNS resolution, with the concrete IP
+// about to be dialed, so it also defeats DNS-rebinding and is re-evaluated on
+// every redirect hop.
+func newDialControl() func(network, address string, c syscall.RawConn) error {
+	return func(_, address string, _ syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return fmt.Errorf("parsing dial address %q: %w", address, err)
+		}
+
+		ip := net.ParseIP(host)
+		if !isPublicIP(ip) {
+			return fmt.Errorf("%w: %s", ErrBlockedAddress, address)
+		}
+
+		return nil
+	}
+}
+
+// limitedBody wraps a response body and returns ErrResponseTooLarge once more
+// than max bytes have been read, so a single response cannot exhaust memory.
+type limitedBody struct {
+	body io.ReadCloser
+	max  int64
+	read int64
+}
+
+func (l *limitedBody) Read(p []byte) (int, error) {
+	if l.read > l.max {
+		return 0, ErrResponseTooLarge
+	}
+
+	n, err := l.body.Read(p)
+	l.read += int64(n)
+
+	if l.read > l.max {
+		return n, ErrResponseTooLarge
+	}
+
+	return n, err //nolint:wrapcheck // must forward io.EOF and other sentinels unwrapped
+}
+
+func (l *limitedBody) Close() error {
+	return l.body.Close() //nolint:wrapcheck // transparent pass-through of the wrapped body
+}
+
+// safeTransport wraps a base RoundTripper enforcing the response size limit.
+// SSRF protection is enforced one layer below, in the dialer Control function.
+type safeTransport struct {
+	base http.RoundTripper
+	max  int64
+}
+
+func (t *safeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // http.Client inspects the transport error; keep it intact
+	}
+
+	// Reject early when the server advertises an over-limit Content-Length.
+	if resp.ContentLength > t.max {
+		_ = resp.Body.Close()
+
+		return nil, ErrResponseTooLarge
+	}
+
+	resp.Body = &limitedBody{body: resp.Body, max: t.max}
+
+	return resp, nil
+}
+
+// SafeHTTPClient builds an *http.Client hardened against SSRF and unbounded
+// downloads. When allowPrivate is true the SSRF address filtering is disabled
+// (used for trusted input and tests that target loopback servers); the response
+// size limit is always enforced.
+func SafeHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	if !allowPrivate {
+		dialer.Control = newDialControl()
+	}
+
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &safeTransport{base: transport, max: MaxResponseBytes},
+	}
+}

--- a/internal/safehttp_test.go
+++ b/internal/safehttp_test.go
@@ -1,0 +1,136 @@
+package netutil
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIsPublicIP(t *testing.T) {
+	cases := map[string]bool{
+		"8.8.8.8":         true,
+		"1.1.1.1":         true,
+		"93.184.216.34":   true,
+		"127.0.0.1":       false, // loopback
+		"10.0.0.1":        false, // private
+		"192.168.1.1":     false, // private
+		"172.16.0.1":      false, // private
+		"169.254.169.254": false, // link-local (cloud metadata)
+		"100.64.0.1":      false, // CGNAT
+		"0.0.0.0":         false, // unspecified
+		"::1":             false, // IPv6 loopback
+		"fc00::1":         false, // IPv6 ULA
+		"fe80::1":         false, // IPv6 link-local
+	}
+
+	for addr, want := range cases {
+		got := isPublicIP(net.ParseIP(addr))
+		if got != want {
+			t.Errorf("isPublicIP(%s) = %v, want %v", addr, got, want)
+		}
+	}
+}
+
+// TestSafeHTTPClientBlocksPrivate proves the default (allowPrivate=false) client
+// refuses to connect to a loopback address, defeating SSRF, while the opt-out
+// client can reach it.
+func TestSafeHTTPClientBlocksPrivate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	blocked := SafeHTTPClient(5*time.Second, false)
+	if _, err := blocked.Get(srv.URL); err == nil {
+		t.Fatal("expected the SSRF guard to block the loopback request")
+	} else if !errors.Is(err, ErrBlockedAddress) && !strings.Contains(err.Error(), "non-public") {
+		t.Errorf("expected a blocked-address error, got: %v", err)
+	}
+
+	allowed := SafeHTTPClient(5*time.Second, true)
+	resp, err := allowed.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected the opt-out client to reach the server, got: %v", err)
+	}
+	_ = resp.Body.Close()
+}
+
+// roundTripFunc lets us stub a RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newResponse(body string, contentLength int64) *http.Response {
+	return &http.Response{
+		StatusCode:    200,
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: contentLength,
+		Header:        make(http.Header),
+	}
+}
+
+func TestResponseSizeLimitOnRead(t *testing.T) {
+	// Unknown Content-Length, body larger than max: the limit must trigger while
+	// reading the body.
+	transport := &safeTransport{
+		base: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return newResponse(strings.Repeat("A", 100), -1), nil
+		}),
+		max: 10,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+
+	_, err = io.ReadAll(resp.Body)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("expected ErrResponseTooLarge while reading, got: %v", err)
+	}
+}
+
+func TestResponseSizeLimitOnContentLength(t *testing.T) {
+	// Advertised Content-Length over the limit must be rejected up front.
+	transport := &safeTransport{
+		base: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return newResponse("small", 1000), nil
+		}),
+		max: 10,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if _, err := transport.RoundTrip(req); !errors.Is(err, ErrResponseTooLarge) {
+		t.Errorf("expected ErrResponseTooLarge from Content-Length check, got: %v", err)
+	}
+}
+
+func TestResponseUnderLimitIsReadFully(t *testing.T) {
+	const body = "within limit"
+	transport := &safeTransport{
+		base: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return newResponse(body, int64(len(body))), nil
+		}),
+		max: MaxResponseBytes,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("body mismatch: got %q, want %q", got, body)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -75,6 +75,15 @@ type ParserConfig struct {
 	// Timeout is the maximum duration for each HTTP request during external checks.
 	// Defaults to 30s if zero.
 	Timeout time.Duration
+
+	// AllowNetworkToPrivateHosts allows the external checks to connect to
+	// non-public addresses (loopback, private, link-local, ...).
+	//
+	// It is false by default so that URLs coming from an untrusted
+	// publiccode.yml cannot be abused to perform SSRF against internal services
+	// or cloud metadata endpoints. Enable it only when the input is trusted
+	// (or in tests targeting a local server).
+	AllowNetworkToPrivateHosts bool
 }
 
 const defaultHTTPTimeout = 30 * time.Second
@@ -110,7 +119,10 @@ func NewParser(config ParserConfig) (*Parser, error) {
 		timeout = defaultHTTPTimeout
 	}
 
-	httpClient := &http.Client{Timeout: timeout}
+	// Hardened HTTP client: refuses connections to non-public addresses (SSRF)
+	// and caps the size of each response (resource exhaustion). See
+	// internal/safehttp.go.
+	httpClient := urlutil.SafeHTTPClient(timeout, config.AllowNetworkToPrivateHosts)
 	vcsurl.Client = httpClient
 	p := Parser{
 		disableNetwork:        config.DisableNetwork,

--- a/parser_ssrf_test.go
+++ b/parser_ssrf_test.go
@@ -1,0 +1,47 @@
+package publiccode
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestParseBlocksSSRFByDefault proves that, with the default configuration used
+// by the publiccode-crawler, an attacker-controlled URL pointing at an internal
+// (here: loopback) address is refused, preventing SSRF. The opt-in flag lets
+// trusted callers reach it.
+func TestParseBlocksSSRFByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/yaml")
+		_, _ = w.Write([]byte("publiccodeYmlVersion: \"0.4\"\n"))
+	}))
+	defer srv.Close()
+
+	p, err := NewParser(ParserConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.Parse(srv.URL + "/publiccode.yml")
+	if err == nil {
+		t.Fatal("expected the default parser to block the loopback (SSRF) request")
+	}
+	if !strings.Contains(err.Error(), "non-public") {
+		t.Errorf("expected a blocked-address error, got: %v", err)
+	}
+
+	// With the opt-out enabled the same request is allowed to connect (it then
+	// fails validation for unrelated reasons, but it is no longer blocked at the
+	// network layer).
+	pAllowed, err := NewParser(ParserConfig{AllowNetworkToPrivateHosts: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = pAllowed.Parse(srv.URL + "/publiccode.yml"); err != nil {
+		if strings.Contains(err.Error(), "non-public") {
+			t.Errorf("opt-out client must not be blocked at the network layer, got: %v", err)
+		}
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -146,7 +146,7 @@ func TestParseTimeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, err := NewParser(ParserConfig{Timeout: 1 * time.Millisecond})
+	p, err := NewParser(ParserConfig{Timeout: 1 * time.Millisecond, AllowNetworkToPrivateHosts: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestParseTimeout(t *testing.T) {
 		t.Fatal("expected timeout error, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "timeout") {
+	if lower := strings.ToLower(err.Error()); !strings.Contains(lower, "deadline exceeded") && !strings.Contains(lower, "timeout") {
 		t.Errorf("expected timeout error, got: %v", err)
 	}
 }
@@ -187,7 +187,7 @@ func TestValidationTimeout(t *testing.T) {
 	}))
 	defer fast.Close()
 
-	p, err := NewParser(ParserConfig{Timeout: 1 * time.Millisecond})
+	p, err := NewParser(ParserConfig{Timeout: 1 * time.Millisecond, AllowNetworkToPrivateHosts: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestValidationTimeout(t *testing.T) {
 		t.Fatal("expected timeout error, got nil")
 	}
 
-	if !strings.Contains(err.Error(), "deadline exceeded") && !strings.Contains(err.Error(), "timeout") {
+	if lower := strings.ToLower(err.Error()); !strings.Contains(lower, "deadline exceeded") && !strings.Contains(lower, "timeout") {
 		t.Errorf("expected timeout error, got: %v", err)
 	}
 }

--- a/validations_test.go
+++ b/validations_test.go
@@ -96,7 +96,7 @@ func TestIsReachableNon200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, _ := NewParser(ParserConfig{})
+	p, _ := NewParser(ParserConfig{AllowNetworkToPrivateHosts: true})
 	parsed, _ := url.Parse(srv.URL + "/path")
 	reachable, err := p.isReachable(*parsed)
 	if reachable {
@@ -185,7 +185,7 @@ func TestValidLogoRemoteDownloadFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, _ := NewParser(ParserConfig{})
+	p, _ := NewParser(ParserConfig{AllowNetworkToPrivateHosts: true})
 	parsed, _ := url.Parse(srv.URL + "/logo.png")
 	ok, err := p.validLogo(*parsed, true)
 	// The downloaded file is not a valid PNG, so DecodeConfig should fail.
@@ -204,7 +204,7 @@ func TestIsReachableSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p, _ := NewParser(ParserConfig{})
+	p, _ := NewParser(ParserConfig{AllowNetworkToPrivateHosts: true})
 	parsed, _ := url.Parse(srv.URL + "/path")
 	reachable, err := p.isReachable(*parsed)
 	if !reachable {


### PR DESCRIPTION
## Vulnerability (SSRF + unbounded download — medium)

The parser runs external checks (URL reachability, logo/screenshot download) on URLs taken from the `publiccode.yml` under analysis — `url`, `landingURL`, `roadmap`, `logo`, `monochromeLogo`, `screenshots`, `documentation`, `apiDocumentation`. When the input is untrusted — as it is for the **publiccode-crawler**, which parses arbitrary repositories — those URLs were fetched with no restriction:

- **SSRF**: a URL such as `http://169.254.169.254/…` (cloud metadata) or `http://10.0.0.5/…` forced the parser host to issue requests into internal networks.
- **Resource exhaustion**: responses were read in full (`httpclient-lib-go` does `ReadAll`, and `internal.downloadFile` copies the whole body), so an endless/huge response could exhaust memory and disk.

All remote fetches funnel through the parser's single `*http.Client` (`p.client`, and `p.httpclient` which wraps it).

## Fix (`internal/safehttp.go`, wired in `NewParser`)

- **SSRF guard**: a `net.Dialer.Control` callback refuses connections to non-public addresses — loopback, private (RFC 1918 / RFC 4193), link-local (incl. `169.254.169.254`), CGNAT (`100.64/10`), multicast and unspecified. It runs **after DNS resolution**, on the concrete IP about to be dialed, so it also defeats DNS-rebinding and is re-evaluated on every redirect hop.
- **Size cap**: a wrapping `RoundTripper` limits each response to **20 MiB**, rejecting an over-limit `Content-Length` up front and failing the read once the cap is exceeded (`ReadAll` then returns an error instead of consuming unbounded memory).

A new `ParserConfig.AllowNetworkToPrivateHosts` (default **false**) lets trusted callers — or tests targeting a loopback server — opt out of the SSRF filtering. The size limit is always enforced. The crawler, using the default config, is protected automatically.

## Tests

- `internal/safehttp_test.go`: `isPublicIP` classification (public vs loopback/private/link-local/CGNAT/ULA/…); the dialer refuses a loopback server by default and reaches it with the opt-out; both size-limit paths (read-time and `Content-Length`); under-limit body read fully.
- `parser_ssrf_test.go`: end-to-end `Parse()` of a loopback URL is **blocked by default** and not blocked with the opt-out.
- Existing network tests (which use loopback `httptest` servers) set the opt-out so they keep exercising real reachability.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` and `golangci-lint run` (v2.11.3, repo config, `default: all`) all pass — **0 lint issues**.
