### PR TITLE
fix: report the validated file name in the diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Example:
 
 ```shell
 $ publiccode-parser mypubliccode.yml
-publiccode.yml:36:1: error: developmentStatus: developmentStatus must be one of the following: "concept", "development", "beta", "stable" or "obsolete"
-publiccode.yml:48:3: warning: legal.authorsFile: This key is DEPRECATED and will be removed in the future. It's safe to drop it
-publiccode.yml:12:5: warning: description.en.genericName: This key is DEPRECATED and will be removed in the future. It's safe to drop it
+mypubliccode.yml:36:1: error: developmentStatus: developmentStatus must be one of the following: "concept", "development", "beta", "stable" or "obsolete"
+mypubliccode.yml:48:3: warning: legal.authorsFile: This key is DEPRECATED and will be removed in the future. It's safe to drop it
+mypubliccode.yml:12:5: warning: description.en.genericName: This key is DEPRECATED and will be removed in the future. It's safe to drop it
 ```
 
 Run `publiccode-parser --help` for the available command line flags.

--- a/errors.go
+++ b/errors.go
@@ -15,7 +15,14 @@ func (e ParseError) Error() string {
 	return e.Reason
 }
 
+// defaultFileName is reported by diagnostics coming from an input with no
+// name of its own, as happens when parsing a stream.
+const defaultFileName = "publiccode.yml"
+
 type ValidationError struct {
+	// Name of the validated file, with no directory part. It is empty when
+	// the input is a stream, which has no name.
+	File        string `json:"file"`
 	Key         string `json:"key"`
 	Description string `json:"description"`
 	Line        int    `json:"line"`
@@ -28,7 +35,7 @@ func (e ValidationError) Error() string {
 		key = e.Key + ": "
 	}
 
-	return fmt.Sprintf("publiccode.yml:%d:%d: error: %s%s", e.Line, e.Column, key, e.Description)
+	return fmt.Sprintf("%s:%d:%d: error: %s%s", e.fileName(), e.Line, e.Column, key, e.Description)
 }
 
 func (e ValidationError) MarshalJSON() ([]byte, error) {
@@ -44,6 +51,14 @@ func (e ValidationError) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (e ValidationError) fileName() string {
+	if e.File == "" {
+		return defaultFileName
+	}
+
+	return e.File
+}
+
 func newValidationError(key string, description string) ValidationError {
 	return ValidationError{Key: key, Description: description}
 }
@@ -55,13 +70,21 @@ func newValidationErrorf(key string, description string, args ...any) Validation
 //nolint:errname,lll // ValidationWarning is intentionally named as a warning, not an error, even though it implements error.
 type ValidationWarning ValidationError
 
+func newValidationWarning(key string, description string) ValidationWarning {
+	return ValidationWarning{Key: key, Description: description}
+}
+
+func newValidationWarningf(key string, description string, args ...any) ValidationWarning {
+	return newValidationWarning(key, fmt.Sprintf(description, args...))
+}
+
 func (e ValidationWarning) Error() string {
 	key := ""
 	if e.Key != "" {
 		key = e.Key + ": "
 	}
 
-	return fmt.Sprintf("publiccode.yml:%d:%d: warning: %s%s", e.Line, e.Column, key, e.Description)
+	return fmt.Sprintf("%s:%d:%d: warning: %s%s", ValidationError(e).fileName(), e.Line, e.Column, key, e.Description)
 }
 
 func (e ValidationWarning) MarshalJSON() ([]byte, error) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -30,6 +30,24 @@ func TestValidationErrorErrorWithKey(t *testing.T) {
 	}
 }
 
+func TestValidationErrorErrorWithFile(t *testing.T) {
+	e := ValidationError{File: "my-amazing-code.yaml", Key: "foo", Description: "bad field", Line: 3, Column: 4}
+	got := e.Error()
+	want := "my-amazing-code.yaml:3:4: error: foo: bad field"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestValidationWarningErrorWithFile(t *testing.T) {
+	e := ValidationWarning{File: "my-amazing-code.yaml", Key: "foo", Description: "minor issue", Line: 5, Column: 6}
+	got := e.Error()
+	want := "my-amazing-code.yaml:5:6: warning: foo: minor issue"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestValidationErrorMarshalJSON(t *testing.T) {
 	e := ValidationError{Key: "foo", Description: "bad", Line: 1, Column: 1}
 	b, err := e.MarshalJSON()
@@ -64,6 +82,34 @@ func TestValidationWarningMarshalJSON(t *testing.T) {
 
 	if m["type"] != "warning" {
 		t.Errorf("expected type=warning, got %v", m["type"])
+	}
+}
+
+func TestValidationErrorMarshalJSONFile(t *testing.T) {
+	e := ValidationError{File: "my-amazing-code.yaml", Key: "foo", Description: "bad", Line: 1, Column: 2}
+	b, err := e.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(b)
+	want := `{"file":"my-amazing-code.yaml","key":"foo","description":"bad","line":1,"column":2,"type":"error"}`
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestValidationWarningMarshalJSONFile(t *testing.T) {
+	e := ValidationWarning{File: "my-amazing-code.yaml", Key: "foo", Description: "minor", Line: 1, Column: 2}
+	b, err := e.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(b)
+	want := `{"file":"my-amazing-code.yaml","key":"foo","description":"minor","line":1,"column":2,"type":"warning"}`
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
 	}
 }
 

--- a/fields.go
+++ b/fields.go
@@ -67,11 +67,10 @@ func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseU
 	}
 
 	if publiccodev0.MonochromeLogo != nil && *publiccodev0.MonochromeLogo != "" {
-		vr = append(vr, ValidationWarning{
+		vr = append(vr, newValidationWarning(
 			"monochromeLogo",
 			"This key is DEPRECATED and will be removed in the future. Use 'logo' instead",
-			0, 0,
-		})
+		))
 
 		if _, err := isRelativePathOrURL(*publiccodev0.MonochromeLogo, "monochromeLogo"); err != nil {
 			vr = append(vr, err)
@@ -93,11 +92,10 @@ func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseU
 		if publiccodev0.IntendedAudience.Countries != nil {
 			for i, c := range *publiccodev0.IntendedAudience.Countries {
 				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
-					vr = append(vr, ValidationWarning{
+					vr = append(vr, newValidationWarningf(
 						fmt.Sprintf("intendedAudience.countries[%d]", i),
-						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
-						0, 0,
-					})
+						"Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c),
+					))
 				}
 			}
 		}
@@ -105,22 +103,20 @@ func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseU
 		if publiccodev0.IntendedAudience.UnsupportedCountries != nil {
 			for i, c := range *publiccodev0.IntendedAudience.UnsupportedCountries {
 				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
-					vr = append(vr, ValidationWarning{
+					vr = append(vr, newValidationWarningf(
 						fmt.Sprintf("intendedAudience.unsupportedCountries[%d]", i),
-						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
-						0, 0,
-					})
+						"Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c),
+					))
 				}
 			}
 		}
 	}
 
 	if publiccodev0.Legal.AuthorsFile != nil {
-		vr = append(vr, ValidationWarning{
+		vr = append(vr, newValidationWarning(
 			"legal.authorsFile",
 			"This key is DEPRECATED and will be removed in the future. It's safe to drop it",
-			0, 0,
-		})
+		))
 
 		if _, err := isRelativePathOrURL(*publiccodev0.Legal.AuthorsFile, "legal.authorsFile"); err != nil {
 			vr = append(vr, err)
@@ -138,35 +134,32 @@ func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseU
 	}
 
 	if publiccodev0.Legal.RepoOwner != nil {
-		vr = append(vr, ValidationWarning{
+		vr = append(vr, newValidationWarning(
 			"legal.repoOwner",
 			"This key is DEPRECATED and will be removed in the future. Use 'organisation.name' instead",
-			0, 0,
-		})
+		))
 	}
 
 	if publiccodev0.InputTypes != nil {
-		vr = append(vr, ValidationWarning{
+		vr = append(vr, newValidationWarning(
 			"inputTypes",
 			"This key is DEPRECATED and will be removed in the future. It's safe to drop it",
-			0, 0,
-		})
+		))
 	}
 
 	if publiccodev0.OutputTypes != nil {
-		vr = append(vr, ValidationWarning{
+		vr = append(vr, newValidationWarning(
 			"outputTypes",
 			"This key is DEPRECATED and will be removed in the future. It's safe to drop it",
-			0, 0,
-		})
+		))
 	}
 
 	for lang, desc := range publiccodev0.Description {
 		if len(desc.GenericName) > 0 {
-			vr = append(vr, ValidationWarning{
+			vr = append(vr, newValidationWarning(
 				fmt.Sprintf("description.%s.genericName", lang),
-				"This key is DEPRECATED and will be removed in the future. It's safe to drop it", 0, 0,
-			})
+				"This key is DEPRECATED and will be removed in the future. It's safe to drop it",
+			))
 		}
 
 		if checksNetwork && desc.Documentation != nil {
@@ -219,10 +212,10 @@ func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseU
 	it := publiccodev0.IT
 
 	if publiccodev0.It != nil {
-		vr = append(vr, ValidationWarning{
+		vr = append(vr, newValidationWarning(
 			"it",
-			"Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead", 0, 0,
-		})
+			"Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead",
+		))
 
 		it = publiccodev0.It
 	}
@@ -235,23 +228,20 @@ func validateFieldsV0(publiccode PublicCode, parser *Parser, network bool, baseU
 
 	if it != nil {
 		if it.Conforme != nil {
-			vr = append(vr, ValidationWarning{
+			vr = append(vr, newValidationWarning(
 				"IT.conforme",
-				"This key is DEPRECATED and will be removed in the future. It's safe to drop it", 0, 0,
-			})
+				"This key is DEPRECATED and will be removed in the future. It's safe to drop it",
+			))
 		}
 
 		if it.Riuso.CodiceIPA != "" {
 			if sharedValidate.Var(it.Riuso.CodiceIPA, "is_italian_ipa_code") == nil {
-				vr = append(vr, ValidationWarning{
+				vr = append(vr, newValidationWarningf(
 					"IT.riuso.codiceIPA",
-					fmt.Sprintf(
-						"This key is DEPRECATED and will be removed in the future. "+
-							"Use 'organisation.uri' and set it to 'urn:x-italian-pa:%s' instead",
-						it.Riuso.CodiceIPA,
-					),
-					0, 0,
-				})
+					"This key is DEPRECATED and will be removed in the future. "+
+						"Use 'organisation.uri' and set it to 'urn:x-italian-pa:%s' instead",
+					it.Riuso.CodiceIPA,
+				))
 			}
 		}
 	}
@@ -325,11 +315,10 @@ func validateFieldsV1(publiccode PublicCode, parser *Parser, network bool, baseU
 		if publiccodev1.IntendedAudience.Countries != nil {
 			for i, c := range *publiccodev1.IntendedAudience.Countries {
 				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
-					vr = append(vr, ValidationWarning{
+					vr = append(vr, newValidationWarningf(
 						fmt.Sprintf("intendedAudience.countries[%d]", i),
-						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
-						0, 0,
-					})
+						"Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c),
+					))
 				}
 			}
 		}
@@ -337,11 +326,10 @@ func validateFieldsV1(publiccode PublicCode, parser *Parser, network bool, baseU
 		if publiccodev1.IntendedAudience.UnsupportedCountries != nil {
 			for i, c := range *publiccodev1.IntendedAudience.UnsupportedCountries {
 				if sharedValidate.Var(c, "iso3166_1_alpha2_lower_or_upper") == nil && c == strings.ToLower(c) {
-					vr = append(vr, ValidationWarning{
+					vr = append(vr, newValidationWarningf(
 						fmt.Sprintf("intendedAudience.unsupportedCountries[%d]", i),
-						fmt.Sprintf("Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c)),
-						0, 0,
-					})
+						"Lowercase country codes are DEPRECATED. Use uppercase instead ('%s')", strings.ToUpper(c),
+					))
 				}
 			}
 		}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -3,6 +3,7 @@ package publiccode
 import (
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -80,14 +81,34 @@ func checkValidFilesNoNetwork(pattern string, t *testing.T) {
 	}
 }
 
+// Return a copy of the expected diagnostics carrying the name of the file
+// they refer to.
+func withFileName(name string, expected error) error {
+	results, ok := expected.(ValidationResults)
+	if !ok {
+		return expected
+	}
+
+	stamped := make(ValidationResults, len(results))
+	copy(stamped, results)
+
+	setFileName(stamped, name)
+
+	return stamped
+}
+
+// The expected diagnostics are written with no file name, because every test
+// here parses a file whose name the parser reports on each of them.
 func checkParseErrors(t *testing.T, err error, test testType) {
-	if test.err == nil && err != nil {
+	expected := withFileName(path.Base(test.file), test.err)
+
+	if expected == nil && err != nil {
 		t.Errorf("[%s] unexpected error: %v\n", test.file, err)
-	} else if test.err != nil && err == nil {
+	} else if expected != nil && err == nil {
 		t.Errorf("[%s] no error generated\n", test.file)
-	} else if test.err != nil && err != nil {
-		if !reflect.DeepEqual(test.err, err) {
-			t.Errorf("[%s] wrong error generated:\n%T - %s\n- instead of:\n%T - %s", test.file, err, err, test.err, test.err)
+	} else if expected != nil && err != nil {
+		if !reflect.DeepEqual(expected, err) {
+			t.Errorf("[%s] wrong error generated:\n%T - %s\n- instead of:\n%T - %s", test.file, err, err, expected, expected)
 		}
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -185,7 +185,67 @@ func (p *Parser) Parse(uri string) (PublicCode, error) {
 	return p.parseStream(stream, fileURL)
 }
 
-func (p *Parser) parseStream(in io.Reader, fileURL *url.URL) (PublicCode, error) { //nolint:maintidx
+func (p *Parser) parseStream(in io.Reader, fileURL *url.URL) (PublicCode, error) {
+	publiccode, err := p.parseAndValidate(in, fileURL)
+
+	var results ValidationResults
+	if errors.As(err, &results) {
+		setFileName(results, fileNameFromURL(fileURL))
+	}
+
+	return publiccode, err
+}
+
+// fileNameFromURL returns the name to report in the diagnostics for the input
+// at fileURL. Only the last path segment is used, because the errorformat
+// prefix ends at the first colon and a whole URL there would send an editor
+// nowhere.
+func fileNameFromURL(fileURL *url.URL) string {
+	if fileURL == nil {
+		return ""
+	}
+
+	var name string
+
+	if fileURL.Scheme == "file" {
+		name = filepath.Base(fileURL.Path)
+	} else {
+		name = path.Base(fileURL.Path)
+	}
+
+	// Base() answers "." for an empty path and "/" for the root, neither of
+	// which is a file name.
+	if name == "." || name == "/" {
+		return ""
+	}
+
+	return name
+}
+
+// setFileName records name on every diagnostic in results. Both diagnostic
+// types are values, so each one has to be written back into the slice.
+func setFileName(results ValidationResults, name string) {
+	if name == "" {
+		return
+	}
+
+	for i, result := range results {
+		var valErr ValidationError
+
+		var valWarn ValidationWarning
+
+		switch {
+		case errors.As(result, &valErr):
+			valErr.File = name
+			results[i] = valErr
+		case errors.As(result, &valWarn):
+			valWarn.File = name
+			results[i] = valWarn
+		}
+	}
+}
+
+func (p *Parser) parseAndValidate(in io.Reader, fileURL *url.URL) (PublicCode, error) { //nolint:maintidx
 	b, err := io.ReadAll(in)
 	if err != nil {
 		return nil, ValidationResults{newValidationErrorf("", "Can't read the stream: %v", err)}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,11 +2,13 @@ package publiccode
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -224,6 +226,87 @@ func TestToURL(t *testing.T) {
 
 		if *u != *out {
 			t.Errorf("%s: expected %v got %v", in, out, u)
+		}
+	}
+}
+
+// The diagnostics must name the file that was validated, whatever it is
+// called, or an editor reading the errorformat output jumps to the wrong file.
+func TestParseReportsInputFileName(t *testing.T) {
+	source, err := os.ReadFile("testdata/v0/invalid/categories_invalid.yml")
+	if err != nil {
+		t.Fatalf("can't read the fixture: %v", err)
+	}
+
+	file := filepath.Join(t.TempDir(), "my-amazing-code.yaml")
+	if err = os.WriteFile(file, source, 0o600); err != nil {
+		t.Fatalf("can't write the fixture copy: %v", err)
+	}
+
+	parser, err := NewParser(ParserConfig{DisableExternalChecks: true})
+	if err != nil {
+		t.Fatalf("can't create parser: %v", err)
+	}
+
+	_, err = parser.Parse(file)
+
+	var results ValidationResults
+	if !errors.As(err, &results) {
+		t.Fatalf("expected validation results, got %T: %v", err, err)
+	}
+
+	for _, result := range results {
+		var ve ValidationError
+		if errors.As(result, &ve) && ve.File != "my-amazing-code.yaml" {
+			t.Errorf("got file %q, want %q", ve.File, "my-amazing-code.yaml")
+		}
+	}
+
+	want := "my-amazing-code.yaml:13:5: error: "
+	if !strings.HasPrefix(results.Error(), want) {
+		t.Errorf("got %q, want a diagnostic starting with %q", results.Error(), want)
+	}
+}
+
+// A stream carries no name, so its diagnostics keep the default one.
+func TestParseStreamReportsDefaultFileName(t *testing.T) {
+	source, err := os.ReadFile("testdata/v0/invalid/categories_invalid.yml")
+	if err != nil {
+		t.Fatalf("can't read the fixture: %v", err)
+	}
+
+	parser, err := NewParser(ParserConfig{DisableExternalChecks: true})
+	if err != nil {
+		t.Fatalf("can't create parser: %v", err)
+	}
+
+	_, err = parser.ParseStream(bytes.NewReader(source))
+	if err == nil {
+		t.Fatal("expected validation results, got nil")
+	}
+
+	want := "publiccode.yml:13:5: error: "
+	if !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("got %q, want a diagnostic starting with %q", err.Error(), want)
+	}
+}
+
+// Test the fileNameFromURL function
+func TestFileNameFromURL(t *testing.T) {
+	expected := []struct {
+		in   *url.URL
+		want string
+	}{
+		{nil, ""},
+		{&url.URL{Scheme: "file", Path: "/path/to/my-amazing-code.yaml"}, "my-amazing-code.yaml"},
+		{&url.URL{Scheme: "file", Path: ""}, ""},
+		{&url.URL{Scheme: "https", Host: "example.org", Path: "/dir/publiccode.yml"}, "publiccode.yml"},
+		{&url.URL{Scheme: "https", Host: "example.org", Path: "/"}, ""},
+	}
+
+	for _, test := range expected {
+		if got := fileNameFromURL(test.in); got != test.want {
+			t.Errorf("%v: expected %q got %q", test.in, test.want, got)
 		}
 	}
 }

--- a/publiccode-parser/publiccode_parser_test.go
+++ b/publiccode-parser/publiccode_parser_test.go
@@ -100,6 +100,19 @@ func TestRunJSONInvalidFileIsList(t *testing.T) {
 	}
 }
 
+func TestRunJSONReportsInputFileName(t *testing.T) {
+	_, stdout, _ := runCLI(t, "-no-external-checks", "-json", invalidFile)
+
+	results := unmarshalList(t, stdout)
+	if len(results) == 0 {
+		t.Fatalf("expected at least one entry, got %q", stdout)
+	}
+
+	if results[0]["file"] != "categories_invalid.yml" {
+		t.Errorf("expected the name of the validated file, got %v", results[0]["file"])
+	}
+}
+
 func TestRunJSONUnreadableFileIsList(t *testing.T) {
 	_, stdout, stderr := runCLI(t, "-no-external-checks", "-json", notThereFile)
 

--- a/v0_test.go
+++ b/v0_test.go
@@ -15,7 +15,7 @@ func TestValidTestcasesV0_NoNetwork(t *testing.T) {
 func TestValidWithWarningTestcasesV0_NoNetwork(t *testing.T) {
 	expected := map[string]error{
 		"authorsFile.yml": ValidationResults{
-			ValidationWarning{"legal.authorsFile", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 71, 3},
+			ValidationWarning{"", "legal.authorsFile", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 71, 3},
 		},
 	}
 
@@ -42,49 +42,49 @@ func TestInvalidTestcasesV0_NoNetwork(t *testing.T) {
 	expected := map[string]error{
 		// logo
 		"logo_missing_file.yml": ValidationResults{
-			ValidationError{"logo", "no such file: " + cwd + "/testdata/v0/invalid/no-network/no_such_file.png", 18, 1},
+			ValidationError{"", "logo", "no such file: " + cwd + "/testdata/v0/invalid/no-network/no_such_file.png", 18, 1},
 		},
 		"logo_invalid_png.yml": ValidationResults{
-			ValidationError{"logo", "image: unknown format", 18, 1},
+			ValidationError{"", "logo", "image: unknown format", 18, 1},
 		},
 
 		// landingURL
 		"landingURL_invalid.yml": ValidationResults{
 			// Just a syntax check here, no check for reachability as network is disabled
-			ValidationError{"landingURL", "landingURL must be an HTTP URL", 8, 1},
+			ValidationError{"", "landingURL", "landingURL must be an HTTP URL", 8, 1},
 		},
 
 		// monochromeLogo
 		"monochromeLogo_invalid_png.yml": ValidationResults{
-			ValidationWarning{"monochromeLogo", "This key is DEPRECATED and will be removed in the future. Use 'logo' instead", 18, 1},
-			ValidationError{"monochromeLogo", "image: unknown format", 18, 1},
+			ValidationWarning{"", "monochromeLogo", "This key is DEPRECATED and will be removed in the future. Use 'logo' instead", 18, 1},
+			ValidationError{"", "monochromeLogo", "image: unknown format", 18, 1},
 		},
 
 		// YAML 1.1 boolean aliases must be rejected
 		"localisation_localisationReady_yaml11_yes.yml": ValidationResults{
-			ValidationError{"localisation.localisationReady", "wrong type for this field", 51, 1},
-			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 51, 3},
-			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
+			ValidationError{"", "localisation.localisationReady", "wrong type for this field", 51, 1},
+			ValidationError{"", "localisation.localisationReady", "localisationReady is a required field", 51, 3},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
 		},
 		"localisation_localisationReady_yaml11_no.yml": ValidationResults{
-			ValidationError{"localisation.localisationReady", "wrong type for this field", 51, 1},
-			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 51, 3},
-			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
+			ValidationError{"", "localisation.localisationReady", "wrong type for this field", 51, 1},
+			ValidationError{"", "localisation.localisationReady", "localisationReady is a required field", 51, 3},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
 		},
 		"localisation_localisationReady_yaml11_on.yml": ValidationResults{
-			ValidationError{"localisation.localisationReady", "wrong type for this field", 51, 1},
-			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 51, 3},
-			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
+			ValidationError{"", "localisation.localisationReady", "wrong type for this field", 51, 1},
+			ValidationError{"", "localisation.localisationReady", "localisationReady is a required field", 51, 3},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
 		},
 		"localisation_localisationReady_yaml11_off.yml": ValidationResults{
-			ValidationError{"localisation.localisationReady", "wrong type for this field", 51, 1},
-			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 51, 3},
-			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
+			ValidationError{"", "localisation.localisationReady", "wrong type for this field", 51, 1},
+			ValidationError{"", "localisation.localisationReady", "localisationReady is a required field", 51, 3},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages is a required field", 52, 3},
 		},
 
 		// supports
 		"supports_unknown_alias.yml": ValidationResults{
-			ValidationError{"supports[0].id", "id contains an unknown alias (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/aliases-list.rst)", 17, 5},
+			ValidationError{"", "supports[0].id", "id contains an unknown alias (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/aliases-list.rst)", 17, 5},
 		},
 	}
 
@@ -111,9 +111,10 @@ func TestInvalidTestcasesV0_NoNetwork(t *testing.T) {
 func TestInvalidTestcasesV0(t *testing.T) {
 	expected := map[string]error{
 		// publiccodeYmlVersion
-		"publiccodeYmlVersion_missing.yml": ValidationResults{ValidationError{"publiccodeYmlVersion", "publiccodeYmlVersion is a required field", 0, 0}},
+		"publiccodeYmlVersion_missing.yml": ValidationResults{ValidationError{"", "publiccodeYmlVersion", "publiccodeYmlVersion is a required field", 0, 0}},
 		"publiccodeYmlVersion_invalid.yml": ValidationResults{
 			ValidationError{
+				"",
 				"publiccodeYmlVersion",
 				"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0, 0.5.0, 0.5, 0.7.0, 0.7",
 				0,
@@ -121,103 +122,104 @@ func TestInvalidTestcasesV0(t *testing.T) {
 			},
 		},
 		"publiccodeYmlVersion_wrong_type.yml": ValidationResults{
-			ValidationError{"publiccodeYmlVersion", "wrong type for this field", 2, 1},
+			ValidationError{"", "publiccodeYmlVersion", "wrong type for this field", 2, 1},
 		},
 
 		// name
-		"name_missing.yml": ValidationResults{ValidationError{"name", "name is a required field", 1, 1}},
-		"name_nil.yml":     ValidationResults{ValidationError{"name", "name is a required field", 4, 1}},
+		"name_missing.yml": ValidationResults{ValidationError{"", "name", "name is a required field", 1, 1}},
+		"name_nil.yml":     ValidationResults{ValidationError{"", "name", "name is a required field", 4, 1}},
 		"name_wrong_type.yml": ValidationResults{
-			ValidationError{"name", "wrong type for this field", 4, 1},
-			ValidationError{"name", "name is a required field", 4, 1},
+			ValidationError{"", "name", "wrong type for this field", 4, 1},
+			ValidationError{"", "name", "name is a required field", 4, 1},
 		},
 
 		// applicationSuite
-		"applicationSuite_wrong_type.yml": ValidationResults{ValidationError{"applicationSuite", "wrong type for this field", 4, 1}},
+		"applicationSuite_wrong_type.yml": ValidationResults{ValidationError{"", "applicationSuite", "wrong type for this field", 4, 1}},
 
 		// url
-		"url_missing.yml": ValidationResults{ValidationError{"url", "url is a required field", 1, 1}},
+		"url_missing.yml": ValidationResults{ValidationError{"", "url", "url is a required field", 1, 1}},
 		"url_wrong_type.yml": ValidationResults{
-			ValidationError{"url", "wrong type for this field", 6, 1},
-			ValidationError{"url", "url is a required field", 6, 1},
+			ValidationError{"", "url", "wrong type for this field", 6, 1},
+			ValidationError{"", "url", "url is a required field", 6, 1},
 		},
 		"url_invalid.yml": ValidationResults{
-			ValidationError{"url", "url must be a valid URL", 6, 1},
-			ValidationError{"url", "'foobar' not reachable: missing URL scheme", 6, 1},
-			ValidationError{"url", "is not a valid code repository", 6, 1},
+			ValidationError{"", "url", "url must be a valid URL", 6, 1},
+			ValidationError{"", "url", "'foobar' not reachable: missing URL scheme", 6, 1},
+			ValidationError{"", "url", "is not a valid code repository", 6, 1},
 		},
 
 		// landingURL
 		"landingURL_wrong_type.yml": ValidationResults{
-			ValidationError{"landingURL", "wrong type for this field", 8, 1},
+			ValidationError{"", "landingURL", "wrong type for this field", 8, 1},
 		},
 		"landingURL_invalid.yml": ValidationResults{
-			ValidationError{"landingURL", "landingURL must be an HTTP URL", 8, 1},
-			ValidationError{"landingURL", "'???' not reachable: missing URL scheme", 8, 1},
+			ValidationError{"", "landingURL", "landingURL must be an HTTP URL", 8, 1},
+			ValidationError{"", "landingURL", "'???' not reachable: missing URL scheme", 8, 1},
 		},
 
 		// isBasedOn
 		"isBasedOn_wrong_type.yml": ValidationResults{
-			ValidationError{"isBasedOn.foobar", "wrong type for this field", 10, 1},
+			ValidationError{"", "isBasedOn.foobar", "wrong type for this field", 10, 1},
 		},
 		"isBasedOn_bad_url_array.yml": ValidationResults{
-			ValidationError{"isBasedOn[1]", "isBasedOn[1] must be a valid URL", 11, 5},
+			ValidationError{"", "isBasedOn[1]", "isBasedOn[1] must be a valid URL", 11, 5},
 		},
 		"isBasedOn_bad_url_string.yml": ValidationResults{
-			ValidationError{"isBasedOn[0]", "isBasedOn[0] must be a valid URL", 9, 1},
+			ValidationError{"", "isBasedOn[0]", "isBasedOn[0] must be a valid URL", 9, 1},
 		},
 
 		// softwareVersion
 		"softwareVersion_wrong_type.yml": ValidationResults{
-			ValidationError{"softwareVersion", "wrong type for this field", 8, 1},
+			ValidationError{"", "softwareVersion", "wrong type for this field", 8, 1},
 		},
 
 		// releaseDate
-		"releaseDate_empty.yml": ValidationResults{ValidationError{"releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1}},
+		"releaseDate_empty.yml": ValidationResults{ValidationError{"", "releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1}},
 		"releaseDate_wrong_type.yml": ValidationResults{
-			ValidationError{"releaseDate", "wrong type for this field", 8, 1},
+			ValidationError{"", "releaseDate", "wrong type for this field", 8, 1},
 		},
 		"releaseDate_invalid.yml": ValidationResults{
-			ValidationError{"releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1},
+			ValidationError{"", "releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1},
 		},
 		"releaseDate_datetime.yml": ValidationResults{
-			ValidationError{"releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1},
+			ValidationError{"", "releaseDate", "releaseDate must be a date with format 'YYYY-MM-DD'", 8, 1},
 		},
 
 		// logo
 		"logo_wrong_type.yml": ValidationResults{
-			ValidationError{"logo", "wrong type for this field", 18, 1},
+			ValidationError{"", "logo", "wrong type for this field", 18, 1},
 		},
 		"logo_unsupported_extension.yml": ValidationResults{
-			ValidationError{"logo", "invalid file extension for: " + cwd + "/testdata/v0/invalid/logo.mpg", 18, 1},
+			ValidationError{"", "logo", "invalid file extension for: " + cwd + "/testdata/v0/invalid/logo.mpg", 18, 1},
 		},
 		"logo_missing_file.yml": ValidationResults{
-			ValidationError{"logo", "no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 18, 1},
+			ValidationError{"", "logo", "no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 18, 1},
 		},
 		"logo_absolute_path.yml": ValidationResults{
-			ValidationError{"logo", "is an absolute path. Only relative paths or HTTP(s) URLs allowed", 18, 1},
+			ValidationError{"", "logo", "is an absolute path. Only relative paths or HTTP(s) URLs allowed", 18, 1},
 		},
 		"logo_file_scheme.yml": ValidationResults{
-			ValidationError{"logo", "is a file:// URL. Only relative paths or HTTP(s) URLs allowed", 18, 1},
+			ValidationError{"", "logo", "is a file:// URL. Only relative paths or HTTP(s) URLs allowed", 18, 1},
 		},
 		"logo_file_scheme2.yml": ValidationResults{
-			ValidationError{"logo", "is a file:// URL. Only relative paths or HTTP(s) URLs allowed", 18, 1},
+			ValidationError{"", "logo", "is a file:// URL. Only relative paths or HTTP(s) URLs allowed", 18, 1},
 		},
 		"logo_file_scheme3.yml": ValidationResults{
-			ValidationError{"logo", "is a file:// URL. Only relative paths or HTTP(s) URLs allowed", 18, 1},
+			ValidationError{"", "logo", "is a file:// URL. Only relative paths or HTTP(s) URLs allowed", 18, 1},
 		},
 		// Local publiccode.yml and URL in logo: should look for the logo remotely
 		"logo_missing_url.yml": ValidationResults{
-			ValidationError{"logo", "HTTP GET failed for https://google.com/no_such_file.png: not found", 18, 1},
+			ValidationError{"", "logo", "HTTP GET failed for https://google.com/no_such_file.png: not found", 18, 1},
 		},
 
 		// monochromeLogo
 		"monochromeLogo_wrong_type.yml": ValidationResults{
-			ValidationError{"monochromeLogo", "wrong type for this field", 18, 1},
+			ValidationError{"", "monochromeLogo", "wrong type for this field", 18, 1},
 		},
 		"monochromeLogo_unsupported_extension.yml": ValidationResults{
-			ValidationWarning{"monochromeLogo", "This key is DEPRECATED and will be removed in the future. Use 'logo' instead", 18, 1},
+			ValidationWarning{"", "monochromeLogo", "This key is DEPRECATED and will be removed in the future. Use 'logo' instead", 18, 1},
 			ValidationError{
+				"",
 				"monochromeLogo",
 				"invalid file extension for: " + cwd + "/testdata/v0/invalid/monochromeLogo.mpg",
 				18,
@@ -225,189 +227,190 @@ func TestInvalidTestcasesV0(t *testing.T) {
 			},
 		},
 		"monochromeLogo_missing_file.yml": ValidationResults{
-			ValidationWarning{"monochromeLogo", "This key is DEPRECATED and will be removed in the future. Use 'logo' instead", 18, 1},
-			ValidationError{"monochromeLogo", "no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 18, 1},
+			ValidationWarning{"", "monochromeLogo", "This key is DEPRECATED and will be removed in the future. Use 'logo' instead", 18, 1},
+			ValidationError{"", "monochromeLogo", "no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 18, 1},
 		},
 
 		// organisation
 		"organisation_wrong_uri.yml": ValidationResults{
-			ValidationError{"organisation.uri", "uri is not a valid URI", 19, 3},
+			ValidationError{"", "organisation.uri", "uri is not a valid URI", 19, 3},
 		},
 		"organisation_wrong_type.yml": ValidationResults{
-			ValidationError{"organisation[0]", "wrong type for this field", 18, 1},
+			ValidationError{"", "organisation[0]", "wrong type for this field", 18, 1},
 		},
 		"organisation_uri_missing.yml": ValidationResults{
-			ValidationError{"organisation.uri", "uri is a required field", 18, 3},
+			ValidationError{"", "organisation.uri", "uri is a required field", 18, 3},
 		},
 		"organisation_uri_wrong_italian_pa.yml": ValidationResults{
-			ValidationError{"organisation.uri", "uri is not a valid URI", 20, 3},
+			ValidationError{"", "organisation.uri", "uri is not a valid URI", 20, 3},
 		},
 		"organisation_uri_wrong_italian_pa2.yml": ValidationResults{
-			ValidationError{"organisation.uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 19, 3},
+			ValidationError{"", "organisation.uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 19, 3},
 		},
 
 		// inputTypes
 		"inputTypes_invalid.yml": ValidationResults{
-			ValidationError{"inputTypes[1]", "inputTypes[1] is not a valid MIME type", 16, 7},
-			ValidationWarning{"inputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 14, 1},
+			ValidationError{"", "inputTypes[1]", "inputTypes[1] is not a valid MIME type", 16, 7},
+			ValidationWarning{"", "inputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 14, 1},
 		},
 		"inputTypes_wrong_type.yml": ValidationResults{
-			ValidationError{"inputTypes.foobar", "wrong type for this field", 15, 1},
+			ValidationError{"", "inputTypes.foobar", "wrong type for this field", 15, 1},
 		},
 
 		// outputTypes
 		"outputTypes_invalid.yml": ValidationResults{
-			ValidationError{"outputTypes[1]", "outputTypes[1] is not a valid MIME type", 16, 7},
-			ValidationWarning{"outputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 14, 1},
+			ValidationError{"", "outputTypes[1]", "outputTypes[1] is not a valid MIME type", 16, 7},
+			ValidationWarning{"", "outputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 14, 1},
 		},
 		"outputTypes_wrong_type.yml": ValidationResults{
-			ValidationError{"outputTypes.foobar", "wrong type for this field", 15, 1},
+			ValidationError{"", "outputTypes.foobar", "wrong type for this field", 15, 1},
 		},
 
 		// platforms
-		"platforms_missing.yml": ValidationResults{ValidationError{"platforms", "platforms must contain more than 0 items", 1, 1}},
+		"platforms_missing.yml": ValidationResults{ValidationError{"", "platforms", "platforms must contain more than 0 items", 1, 1}},
 		"platforms_wrong_type.yml": ValidationResults{
-			ValidationError{"platforms", "wrong type for this field", 9, 1},
-			ValidationError{"platforms", "platforms must contain more than 0 items", 9, 1},
+			ValidationError{"", "platforms", "wrong type for this field", 9, 1},
+			ValidationError{"", "platforms", "platforms must contain more than 0 items", 9, 1},
 		},
 
 		// categories
-		"categories_invalid.yml": ValidationResults{ValidationError{"categories[0]", "categories[0] must be a valid category (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/categories-list.rst)", 13, 5}},
+		"categories_invalid.yml": ValidationResults{ValidationError{"", "categories[0]", "categories[0] must be a valid category (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/categories-list.rst)", 13, 5}},
 
 		// usedBy
 		"usedBy_wrong_type.yml": ValidationResults{
-			ValidationError{"usedBy", "wrong type for this field", 14, 1},
+			ValidationError{"", "usedBy", "wrong type for this field", 14, 1},
 		},
 
 		// fundedBy
 		"fundedBy_wrong_uri.yml": ValidationResults{
-			ValidationError{"fundedBy[0].uri", "uri is not a valid URI", 19, 5},
+			ValidationError{"", "fundedBy[0].uri", "uri is not a valid URI", 19, 5},
 		},
 		"fundedBy_wrong_type.yml": ValidationResults{
-			ValidationError{"fundedBy.name", "wrong type for this field", 18, 1},
+			ValidationError{"", "fundedBy.name", "wrong type for this field", 18, 1},
 		},
 		"fundedBy_uri_missing.yml": ValidationResults{
-			ValidationError{"fundedBy[0].uri", "uri is a required field", 18, 5},
+			ValidationError{"", "fundedBy[0].uri", "uri is a required field", 18, 5},
 		},
 		"fundedBy_uri_wrong_italian_pa.yml": ValidationResults{
-			ValidationError{"fundedBy[0].uri", "uri is not a valid URI", 20, 5},
+			ValidationError{"", "fundedBy[0].uri", "uri is not a valid URI", 20, 5},
 		},
 		"fundedBy_uri_wrong_italian_pa2.yml": ValidationResults{
-			ValidationError{"fundedBy[0].uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 19, 5},
+			ValidationError{"", "fundedBy[0].uri", "uri must be a valid Italian Public Administration Code (iPA) with format 'urn:x-italian-pa:[codiceIPA]' (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 19, 5},
 		},
 
 		// roadmap
 		"roadmap_invalid.yml": ValidationResults{
-			ValidationError{"roadmap", "roadmap must be an HTTP URL", 4, 1},
-			ValidationError{"roadmap", "'foobar' not reachable: missing URL scheme", 4, 1},
+			ValidationError{"", "roadmap", "roadmap must be an HTTP URL", 4, 1},
+			ValidationError{"", "roadmap", "'foobar' not reachable: missing URL scheme", 4, 1},
 		},
 		"roadmap_wrong_type.yml": ValidationResults{
-			ValidationError{"roadmap", "wrong type for this field", 4, 1},
+			ValidationError{"", "roadmap", "wrong type for this field", 4, 1},
 		},
 
 		// developmentStatus
 		"developmentStatus_missing.yml": ValidationResults{
-			ValidationError{"developmentStatus", "developmentStatus is a required field", 1, 1},
+			ValidationError{"", "developmentStatus", "developmentStatus is a required field", 1, 1},
 		},
 		"developmentStatus_invalid.yml": ValidationResults{
-			ValidationError{"developmentStatus", "developmentStatus must be one of the following: \"concept\", \"development\", \"beta\", \"stable\" or \"obsolete\"", 16, 1},
+			ValidationError{"", "developmentStatus", "developmentStatus must be one of the following: \"concept\", \"development\", \"beta\", \"stable\" or \"obsolete\"", 16, 1},
 		},
 		"developmentStatus_wrong_type.yml": ValidationResults{
-			ValidationError{"developmentStatus", "wrong type for this field", 16, 1},
-			ValidationError{"developmentStatus", "developmentStatus is a required field", 16, 1},
+			ValidationError{"", "developmentStatus", "wrong type for this field", 16, 1},
+			ValidationError{"", "developmentStatus", "developmentStatus is a required field", 16, 1},
 		},
 
 		// softwareType
 		"softwareType_missing.yml": ValidationResults{
-			ValidationError{"softwareType", "softwareType is a required field", 1, 1},
+			ValidationError{"", "softwareType", "softwareType is a required field", 1, 1},
 		},
 		"softwareType_invalid.yml": ValidationResults{
-			ValidationError{"softwareType", "softwareType must be one of the following: \"standalone/mobile\", \"standalone/iot\", \"standalone/desktop\", \"standalone/web\", \"standalone/backend\", \"standalone/other\", \"addon\", \"library\" or \"configurationFiles\"", 17, 1},
+			ValidationError{"", "softwareType", "softwareType must be one of the following: \"standalone/mobile\", \"standalone/iot\", \"standalone/desktop\", \"standalone/web\", \"standalone/backend\", \"standalone/other\", \"addon\", \"library\" or \"configurationFiles\"", 17, 1},
 		},
 		"softwareType_wrong_type.yml": ValidationResults{
-			ValidationError{"softwareType", "wrong type for this field", 17, 1},
-			ValidationError{"softwareType", "softwareType is a required field", 17, 1},
+			ValidationError{"", "softwareType", "wrong type for this field", 17, 1},
+			ValidationError{"", "softwareType", "softwareType is a required field", 17, 1},
 		},
 
 		// intendedAudience
 		// intendedAudience.*
 		"intendedAudience_wrong_type.yml": ValidationResults{
-			ValidationError{"intendedAudience", "wrong type for this field", 18, 1},
+			ValidationError{"", "intendedAudience", "wrong type for this field", 18, 1},
 		},
 		"intendedAudience_countries_invalid_country.yml": ValidationResults{
-			ValidationError{"intendedAudience.countries[2]", "countries[2] must be a valid ISO 3166-1 alpha-2 two-letter country code", 22, 7},
+			ValidationError{"", "intendedAudience.countries[2]", "countries[2] must be a valid ISO 3166-1 alpha-2 two-letter country code", 22, 7},
 		},
 		"intendedAudience_countries_invalid_iso_3166_1_alpha_2.yml": ValidationResults{
-			ValidationError{"intendedAudience.countries[2]", "countries[2] must be a valid ISO 3166-1 alpha-2 two-letter country code", 22, 7},
+			ValidationError{"", "intendedAudience.countries[2]", "countries[2] must be a valid ISO 3166-1 alpha-2 two-letter country code", 22, 7},
 		},
 		"intendedAudience_countries_wrong_type.yml": ValidationResults{
-			ValidationError{"intendedAudience.countries", "wrong type for this field", 19, 1},
+			ValidationError{"", "intendedAudience.countries", "wrong type for this field", 19, 1},
 		},
 		"intendedAudience_unsupportedCountries_invalid_country.yml": ValidationResults{
-			ValidationError{"intendedAudience.unsupportedCountries[0]", "unsupportedCountries[0] must be a valid ISO 3166-1 alpha-2 two-letter country code", 20, 7},
+			ValidationError{"", "intendedAudience.unsupportedCountries[0]", "unsupportedCountries[0] must be a valid ISO 3166-1 alpha-2 two-letter country code", 20, 7},
 		},
 		"intendedAudience_unsupportedCountries_wrong_type.yml": ValidationResults{
-			ValidationError{"intendedAudience.unsupportedCountries", "wrong type for this field", 19, 1},
+			ValidationError{"", "intendedAudience.unsupportedCountries", "wrong type for this field", 19, 1},
 		},
 		"intendedAudience_scope_invalid_scope.yml": ValidationResults{
-			ValidationError{"intendedAudience.scope[0]", "scope[0] must be a valid scope (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/scope-list.rst)", 20, 9},
+			ValidationError{"", "intendedAudience.scope[0]", "scope[0] must be a valid scope (see https://github.com/publiccodeyml/publiccode.yml/blob/main/docs/standard/scope-list.rst)", 20, 9},
 		},
 		"intendedAudience_scope_wrong_type.yml": ValidationResults{
-			ValidationError{"intendedAudience.scope", "wrong type for this field", 19, 1},
+			ValidationError{"", "intendedAudience.scope", "wrong type for this field", 19, 1},
 		},
 
 		// description
 		// description.*
 		"description_invalid_language.yml": ValidationResults{
-			ValidationError{"description", "description must be a valid BCP 47 language", 18, 1},
+			ValidationError{"", "description", "description must be a valid BCP 47 language", 18, 1},
 		},
 		"description_en_features_missing.yml": ValidationResults{
-			ValidationError{"description.en.features", "features must contain more than 0 items", 22, 5},
+			ValidationError{"", "description.en.features", "features must contain more than 0 items", 22, 5},
 		},
 		"description_en_features_empty.yml": ValidationResults{
-			ValidationError{"description.en.features", "features must contain more than 0 items", 39, 5},
+			ValidationError{"", "description.en.features", "features must contain more than 0 items", 39, 5},
 		},
 		"description_en_localisedName_wrong_type.yml": ValidationResults{
-			ValidationError{"description.en.localisedName", "wrong type for this field", 21, 1},
-			ValidationError{"description", "description must contain more than 0 items", 18, 1},
+			ValidationError{"", "description.en.localisedName", "wrong type for this field", 21, 1},
+			ValidationError{"", "description", "description must contain more than 0 items", 18, 1},
 		},
 		"description_en_genericName_too_long.yml": ValidationResults{
-			ValidationError{"description.en.genericName", "genericName must be a maximum of 35 characters in length", 22, 5},
-			ValidationWarning{"description.en.genericName", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 22, 5},
+			ValidationError{"", "description.en.genericName", "genericName must be a maximum of 35 characters in length", 22, 5},
+			ValidationWarning{"", "description.en.genericName", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 22, 5},
 		},
 		"description_en_shortDescription_missing.yml": ValidationResults{
-			ValidationError{"description.en.shortDescription", "shortDescription is a required field", 20, 5},
+			ValidationError{"", "description.en.shortDescription", "shortDescription is a required field", 20, 5},
 		},
 		"description_en_longDescription_missing.yml": ValidationResults{
-			ValidationError{"description.en.longDescription", "longDescription is a required field", 20, 5},
+			ValidationError{"", "description.en.longDescription", "longDescription is a required field", 20, 5},
 		},
 		"description_en_longDescription_too_long.yml": ValidationResults{
-			ValidationError{"description.en.longDescription", "longDescription must be a maximum of 10000 characters in length", 27, 5},
+			ValidationError{"", "description.en.longDescription", "longDescription must be a maximum of 10000 characters in length", 27, 5},
 		},
 		"description_en_longDescription_too_short.yml": ValidationResults{
-			ValidationError{"description.en.longDescription", "longDescription must be at least 150 characters in length", 27, 5},
+			ValidationError{"", "description.en.longDescription", "longDescription must be at least 150 characters in length", 27, 5},
 		},
 		"description_en_longDescription_too_short_grapheme_clusters.yml": ValidationResults{
-			ValidationError{"description.en.longDescription", "longDescription must be at least 150 characters in length", 28, 5},
+			ValidationError{"", "description.en.longDescription", "longDescription must be at least 150 characters in length", 28, 5},
 		},
 		"description_en_documentation_invalid.yml": ValidationResults{
-			ValidationError{"description.en.documentation", "documentation must be an HTTP URL", 25, 5},
-			ValidationError{"description.en.documentation", "'not_a_url' not reachable: missing URL scheme", 25, 5},
+			ValidationError{"", "description.en.documentation", "documentation must be an HTTP URL", 25, 5},
+			ValidationError{"", "description.en.documentation", "'not_a_url' not reachable: missing URL scheme", 25, 5},
 		},
 		"description_en_documentation_wrong_type.yml": ValidationResults{
-			ValidationError{"description.en.documentation", "wrong type for this field", 25, 1},
-			ValidationError{"description", "description must contain more than 0 items", 20, 1},
+			ValidationError{"", "description.en.documentation", "wrong type for this field", 25, 1},
+			ValidationError{"", "description", "description must contain more than 0 items", 20, 1},
 		},
 		"description_en_apiDocumentation_invalid.yml": ValidationResults{
-			ValidationError{"description.en.apiDocumentation", "apiDocumentation must be an HTTP URL", 41, 5},
-			ValidationError{"description.en.apiDocumentation", "'abc' not reachable: missing URL scheme", 41, 5},
+			ValidationError{"", "description.en.apiDocumentation", "apiDocumentation must be an HTTP URL", 41, 5},
+			ValidationError{"", "description.en.apiDocumentation", "'abc' not reachable: missing URL scheme", 41, 5},
 		},
 		"description_en_apiDocumentation_wrong_type.yml": ValidationResults{
-			ValidationError{"description.en.apiDocumentation", "wrong type for this field", 43, 1},
-			ValidationError{"description", "description must contain more than 0 items", 20, 1},
+			ValidationError{"", "description.en.apiDocumentation", "wrong type for this field", 43, 1},
+			ValidationError{"", "description", "description must contain more than 0 items", 20, 1},
 		},
 		"description_en_screenshots_missing_file.yml": ValidationResults{
 			ValidationError{
+				"",
 				"description.en.screenshots[0]",
 				"'no_such_file.png' is not an image: no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png",
 				42,
@@ -415,36 +418,39 @@ func TestInvalidTestcasesV0(t *testing.T) {
 			},
 		},
 		"description_en_awards_wrong_type.yml": ValidationResults{
-			ValidationError{"description.en.awards", "wrong type for this field", 40, 1},
-			ValidationError{"description", "description must contain more than 0 items", 18, 1},
+			ValidationError{"", "description.en.awards", "wrong type for this field", 40, 1},
+			ValidationError{"", "description", "description must contain more than 0 items", 18, 1},
 		},
 		"description_en_videos_invalid.yml": ValidationResults{
-			ValidationError{"description.en.videos[0]", "videos[0] must be an HTTP URL", 41, 9},
-			ValidationError{"description.en.videos[0]", "'ABC' is not a valid video URL supporting oEmbed: invalid oEmbed link: ABC", 41, 9},
+			ValidationError{"", "description.en.videos[0]", "videos[0] must be an HTTP URL", 41, 9},
+			ValidationError{"", "description.en.videos[0]", "'ABC' is not a valid video URL supporting oEmbed: invalid oEmbed link: ABC", 41, 9},
 		},
 		"description_en_videos_invalid_oembed.yml": ValidationResults{
-			ValidationError{"description.en.videos[0]", "'https://google.com' is not a valid video URL supporting oEmbed: invalid oEmbed link: https://google.com", 41, 9},
+			ValidationError{"", "description.en.videos[0]", "'https://google.com' is not a valid video URL supporting oEmbed: invalid oEmbed link: https://google.com", 41, 9},
 		},
 
 		// legal
 		// legal.*
-		"legal_missing.yml": ValidationResults{ValidationError{"legal.license", "license is a required field", 0, 0}},
+		"legal_missing.yml": ValidationResults{ValidationError{"", "legal.license", "license is a required field", 0, 0}},
 		"legal_wrong_type.yml": ValidationResults{
-			ValidationError{"legal", "wrong type for this field", 46, 1},
-			ValidationError{"legal.license", "license is a required field", 46, 8},
+			ValidationError{"", "legal", "wrong type for this field", 46, 1},
+			ValidationError{"", "legal.license", "license is a required field", 46, 8},
 		},
-		"legal_license_missing.yml": ValidationResults{ValidationError{"legal.license", "license is a required field", 41, 3}},
+		"legal_license_missing.yml": ValidationResults{ValidationError{"", "legal.license", "license is a required field", 41, 3}},
 		"legal_license_invalid.yml": ValidationResults{ValidationError{
+			"",
 			"legal.license", "license must be a valid license (see https://spdx.org/licenses)", 42, 3,
 		}},
 		"legal_authorsFile_missing_file.yml": ValidationResults{
 			ValidationWarning{
+				"",
 				"legal.authorsFile",
 				"This key is DEPRECATED and will be removed in the future. It's safe to drop it",
 				42,
 				3,
 			},
 			ValidationError{
+				"",
 				"legal.authorsFile",
 				"'" + cwd + "/testdata/v0/invalid/no_such_authors_file.txt' does not exist: no such file: " + cwd + "/testdata/v0/invalid/no_such_authors_file.txt",
 				42,
@@ -455,126 +461,126 @@ func TestInvalidTestcasesV0(t *testing.T) {
 		// maintenance
 		// maintenance.*
 		"maintenance_type_missing.yml": ValidationResults{
-			ValidationError{"maintenance.type", "type is a required field", 47, 3},
+			ValidationError{"", "maintenance.type", "type is a required field", 47, 3},
 		},
 		"maintenance_type_invalid.yml": ValidationResults{
-			ValidationError{"maintenance.type", "type must be one of the following: \"internal\", \"contract\", \"community\" or \"none\"", 45, 3},
+			ValidationError{"", "maintenance.type", "type must be one of the following: \"internal\", \"contract\", \"community\" or \"none\"", 45, 3},
 		},
 		"maintenance_contacts_missing_with_type_community.yml": ValidationResults{
-			ValidationError{"maintenance.contacts", "contacts is a required field when \"type\" is \"community\"", 44, 3},
+			ValidationError{"", "maintenance.contacts", "contacts is a required field when \"type\" is \"community\"", 44, 3},
 		},
 		"maintenance_contacts_missing_with_type_internal.yml": ValidationResults{
-			ValidationError{"maintenance.contacts", "contacts is a required field when \"type\" is \"internal\"", 44, 3},
+			ValidationError{"", "maintenance.contacts", "contacts is a required field when \"type\" is \"internal\"", 44, 3},
 		},
 		"maintenance_contacts_name_missing.yml": ValidationResults{
-			ValidationError{"maintenance.contacts[0].name", "name is a required field", 47, 7},
+			ValidationError{"", "maintenance.contacts[0].name", "name is a required field", 47, 7},
 		},
 		"maintenance_contacts_email_invalid.yml": ValidationResults{
-			ValidationError{"maintenance.contacts[0].email", "email must be a valid email address", 49, 9},
+			ValidationError{"", "maintenance.contacts[0].email", "email must be a valid email address", 49, 9},
 		},
 		"maintenance_contractors_missing_with_type_contract.yml": ValidationResults{
-			ValidationError{"maintenance.contractors", "contractors is a required field when \"type\" is \"contract\"", 44, 3},
+			ValidationError{"", "maintenance.contractors", "contractors is a required field when \"type\" is \"contract\"", 44, 3},
 		},
 		"maintenance_contractors_invalid_type.yml": ValidationResults{
-			ValidationError{"maintenance.contractors", "wrong type for this field", 47, 1},
-			ValidationError{"maintenance.type", "type is a required field", 44, 3},
+			ValidationError{"", "maintenance.contractors", "wrong type for this field", 47, 1},
+			ValidationError{"", "maintenance.type", "type is a required field", 44, 3},
 		},
 		"maintenance_contractors_name_missing.yml": ValidationResults{
-			ValidationError{"maintenance.contractors[0].name", "name is a required field", 47, 7},
+			ValidationError{"", "maintenance.contractors[0].name", "name is a required field", 47, 7},
 		},
 		"maintenance_contractors_until_missing.yml": ValidationResults{
-			ValidationError{"maintenance.contractors[0].until", "until is a required field", 47, 7},
+			ValidationError{"", "maintenance.contractors[0].until", "until is a required field", 47, 7},
 		},
 		"maintenance_contractors_until_invalid.yml": ValidationResults{
-			ValidationError{"maintenance.contractors[0].until", "until must be a date with format 'YYYY-MM-DD'", 49, 7},
+			ValidationError{"", "maintenance.contractors[0].until", "until must be a date with format 'YYYY-MM-DD'", 49, 7},
 		},
 		"maintenance_contractors_email_invalid.yml": ValidationResults{
-			ValidationError{"maintenance.contractors[0].email", "email must be a valid email address", 50, 8},
+			ValidationError{"", "maintenance.contractors[0].email", "email must be a valid email address", 50, 8},
 		},
 		"maintenance_contractors_website_invalid.yml": ValidationResults{
-			ValidationError{"maintenance.contractors[0].website", "website must be an HTTP URL", 52, 7},
+			ValidationError{"", "maintenance.contractors[0].website", "website must be an HTTP URL", 52, 7},
 		},
 		"maintenance_contractors_when_type_is_community.yml": ValidationResults{
-			ValidationError{"maintenance.contractors", "contractors must not be present unless \"type\" is \"contract\"", 46, 3},
+			ValidationError{"", "maintenance.contractors", "contractors must not be present unless \"type\" is \"contract\"", 46, 3},
 		},
 		"maintenance_contractors_when_type_is_internal.yml": ValidationResults{
-			ValidationError{"maintenance.contractors", "contractors must not be present unless \"type\" is \"contract\"", 46, 3},
+			ValidationError{"", "maintenance.contractors", "contractors must not be present unless \"type\" is \"contract\"", 46, 3},
 		},
 		"maintenance_contractors_when_type_is_none.yml": ValidationResults{
-			ValidationError{"maintenance.contractors", "contractors must not be present unless \"type\" is \"contract\"", 46, 3},
+			ValidationError{"", "maintenance.contractors", "contractors must not be present unless \"type\" is \"contract\"", 46, 3},
 		},
 
 		// localisation
 		"localisation_availableLanguages_missing.yml": ValidationResults{
-			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 50, 3},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages is a required field", 50, 3},
 		},
 		"localisation_availableLanguages_empty.yml": ValidationResults{
-			ValidationError{"localisation.availableLanguages", "availableLanguages must contain more than 0 items", 52, 3},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages must contain more than 0 items", 52, 3},
 		},
 		"localisation_availableLanguages_invalid.yml": ValidationResults{
-			ValidationError{"localisation.availableLanguages[0]", "availableLanguages[0] must be a valid BCP 47 language", 53, 8},
+			ValidationError{"", "localisation.availableLanguages[0]", "availableLanguages[0] must be a valid BCP 47 language", 53, 8},
 		},
 		"localisation_localisationReady_missing.yml": ValidationResults{
-			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 52, 3},
+			ValidationError{"", "localisation.localisationReady", "localisationReady is a required field", 52, 3},
 		},
 
 		// dependsOn
 		"dependsOn_open_name_wrong_type.yml": ValidationResults{
-			ValidationError{"dependsOn.open[0]", "wrong type for this field", 56, 1},
+			ValidationError{"", "dependsOn.open[0]", "wrong type for this field", 56, 1},
 		},
 		"dependsOn_open_versionMin_wrong_type.yml": ValidationResults{
-			ValidationError{"dependsOn.open[0].versionMin", "wrong type for this field", 57, 1},
+			ValidationError{"", "dependsOn.open[0].versionMin", "wrong type for this field", 57, 1},
 		},
 		"dependsOn_open_versionMax_wrong_type.yml": ValidationResults{
-			ValidationError{"dependsOn.open[0].versionMax", "wrong type for this field", 57, 1},
+			ValidationError{"", "dependsOn.open[0].versionMax", "wrong type for this field", 57, 1},
 		},
 		"dependsOn_open_version_wrong_type.yml": ValidationResults{
-			ValidationError{"dependsOn.open[0].version", "wrong type for this field", 57, 1},
+			ValidationError{"", "dependsOn.open[0].version", "wrong type for this field", 57, 1},
 		},
 		"dependsOn_open_optional_wrong_type.yml": ValidationResults{
-			ValidationError{"dependsOn.open[0].optional", "wrong type for this field", 57, 1},
+			ValidationError{"", "dependsOn.open[0].optional", "wrong type for this field", 57, 1},
 		},
 
 		// it.*
 		"it_countryExtensionVersion_invalid.yml": ValidationResults{
-			ValidationError{"IT.countryExtensionVersion", "countryExtensionVersion must be one of the following: \"0.2\" or \"1.0\"", 12, 3},
+			ValidationError{"", "IT.countryExtensionVersion", "countryExtensionVersion must be one of the following: \"0.2\" or \"1.0\"", 12, 3},
 		},
 		"it_riuso_codiceIPA_invalid.yml": ValidationResults{
-			ValidationError{"IT.riuso.codiceIPA", "codiceIPA must be a valid Italian Public Administration Code (iPA) (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 55, 5},
+			ValidationError{"", "IT.riuso.codiceIPA", "codiceIPA must be a valid Italian Public Administration Code (iPA) (see https://github.com/publiccodeyml/italian-organizations-ipa-vocabulary)", 55, 5},
 		},
 		"it_IT_duplicated.yml": ValidationResults{
-			ValidationWarning{"it", "Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead", 116, 1},
-			ValidationError{"it", "'IT' key already present. Remove this key", 116, 1},
+			ValidationWarning{"", "it", "Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead", 116, 1},
+			ValidationError{"", "it", "'IT' key already present. Remove this key", 116, 1},
 		},
 		"it_wrong_case.yml": ValidationResults{
-			ValidationError{"It", "unknown field \"It\"", 107, 1},
+			ValidationError{"", "It", "unknown field \"It\"", 107, 1},
 		},
 		"description_en_gb_invalid_bcp47.yml": ValidationResults{
-			ValidationError{"description", "description must be a valid BCP 47 language", 18, 1},
+			ValidationError{"", "description", "description must be a valid BCP 47 language", 18, 1},
 		},
 		"localisation_availableLanguages_invalid_bcp47.yml": ValidationResults{
-			ValidationError{"localisation.availableLanguages[0]", "availableLanguages[0] must be a valid BCP 47 language", 54, 8},
+			ValidationError{"", "localisation.availableLanguages[0]", "availableLanguages[0] must be a valid BCP 47 language", 54, 8},
 		},
 
 		// misc
-		"file_encoding.yml": ValidationResults{ValidationError{"", "Invalid UTF-8", 0, 0}},
-		"invalid_yaml.yml":  ValidationResults{ValidationError{"", "value is not allowed in this context. map key-value is pre-defined", 38, 1}},
+		"file_encoding.yml": ValidationResults{ValidationError{"", "", "Invalid UTF-8", 0, 0}},
+		"invalid_yaml.yml":  ValidationResults{ValidationError{"", "", "value is not allowed in this context. map key-value is pre-defined", 38, 1}},
 		"mostly_empty.yml": ValidationResults{
-			ValidationError{"name", "name is a required field", 1, 1},
-			ValidationError{"url", "url is a required field", 1, 1},
-			ValidationError{"platforms", "platforms must contain more than 0 items", 1, 1},
-			ValidationError{"developmentStatus", "developmentStatus is a required field", 1, 1},
-			ValidationError{"softwareType", "softwareType is a required field", 1, 1},
-			ValidationError{"description[en-US].shortDescription", "shortDescription is a required field", 3, 10},
-			ValidationError{"description[en-US].longDescription", "longDescription is a required field", 3, 10},
-			ValidationError{"description[en-US].features", "features must contain more than 0 items", 3, 10},
-			ValidationError{"legal.license", "license is a required field", 5, 8},
-			ValidationError{"maintenance.type", "type is a required field", 6, 14},
-			ValidationError{"localisation.localisationReady", "localisationReady is a required field", 4, 15},
-			ValidationError{"localisation.availableLanguages", "availableLanguages is a required field", 4, 15},
+			ValidationError{"", "name", "name is a required field", 1, 1},
+			ValidationError{"", "url", "url is a required field", 1, 1},
+			ValidationError{"", "platforms", "platforms must contain more than 0 items", 1, 1},
+			ValidationError{"", "developmentStatus", "developmentStatus is a required field", 1, 1},
+			ValidationError{"", "softwareType", "softwareType is a required field", 1, 1},
+			ValidationError{"", "description[en-US].shortDescription", "shortDescription is a required field", 3, 10},
+			ValidationError{"", "description[en-US].longDescription", "longDescription is a required field", 3, 10},
+			ValidationError{"", "description[en-US].features", "features must contain more than 0 items", 3, 10},
+			ValidationError{"", "legal.license", "license is a required field", 5, 8},
+			ValidationError{"", "maintenance.type", "type is a required field", 6, 14},
+			ValidationError{"", "localisation.localisationReady", "localisationReady is a required field", 4, 15},
+			ValidationError{"", "localisation.availableLanguages", "availableLanguages is a required field", 4, 15},
 		},
 		"unknown_field.yml": ValidationResults{
-			ValidationError{"foobar", "unknown field \"foobar\"", 10, 1},
+			ValidationError{"", "foobar", "unknown field \"foobar\"", 10, 1},
 		},
 	}
 
@@ -606,37 +612,37 @@ func TestValidTestcasesV0(t *testing.T) {
 func TestValidWithWarningsTestcasesV0(t *testing.T) {
 	expected := map[string]error{
 		"unicode_grapheme_clusters.yml": ValidationResults{
-			ValidationWarning{"description.en.genericName", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 23, 5},
+			ValidationWarning{"", "description.en.genericName", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 23, 5},
 		},
 		"valid.minimal.v0.2.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.2 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
+			ValidationWarning{"", "publiccodeYmlVersion", "v0.2 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
 		},
 		"valid.minimal.v0.3.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.3 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
+			ValidationWarning{"", "publiccodeYmlVersion", "v0.3 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
 		},
 		"valid.minimal.v0.4.yml": ValidationResults{
-			ValidationWarning{"publiccodeYmlVersion", "v0.4 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
+			ValidationWarning{"", "publiccodeYmlVersion", "v0.4 is not the latest version, use '0'. Parsing this file as v0.7.", 1, 1},
 		},
 		"valid.mime_types.yml": ValidationResults{
-			ValidationWarning{"inputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 48, 1},
-			ValidationWarning{"outputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 50, 1},
+			ValidationWarning{"", "inputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 48, 1},
+			ValidationWarning{"", "outputTypes", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 50, 1},
 		},
 		"valid_with_it_conforme.yml": ValidationResults{
-			ValidationWarning{"IT.conforme", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 119, 3},
+			ValidationWarning{"", "IT.conforme", "This key is DEPRECATED and will be removed in the future. It's safe to drop it", 119, 3},
 		},
 		"valid_with_country_specific_section_downcase.yml": ValidationResults{
-			ValidationWarning{"it", "Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead", 107, 1},
+			ValidationWarning{"", "it", "Lowercase country codes are DEPRECATED and will be removed in the future. Use 'IT' instead", 107, 1},
 		},
 		"valid_with_lowercase_countries.yml": ValidationResults{
-			ValidationWarning{"intendedAudience.countries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('IT')", 31, 7},
-			ValidationWarning{"intendedAudience.countries[1]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('DE')", 32, 7},
-			ValidationWarning{"intendedAudience.unsupportedCountries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('US')", 34, 7},
+			ValidationWarning{"", "intendedAudience.countries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('IT')", 31, 7},
+			ValidationWarning{"", "intendedAudience.countries[1]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('DE')", 32, 7},
+			ValidationWarning{"", "intendedAudience.unsupportedCountries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('US')", 34, 7},
 		},
 		"valid_with_legal_repoOwner.yml": ValidationResults{
-			ValidationWarning{"legal.repoOwner", "This key is DEPRECATED and will be removed in the future. Use 'organisation.name' instead", 70, 3},
+			ValidationWarning{"", "legal.repoOwner", "This key is DEPRECATED and will be removed in the future. Use 'organisation.name' instead", 70, 3},
 		},
 		"valid_with_IT_riuso_codiceIPA.yml": ValidationResults{
-			ValidationWarning{"IT.riuso.codiceIPA", "This key is DEPRECATED and will be removed in the future. Use 'organisation.uri' and set it to 'urn:x-italian-pa:pcm' instead", 119, 5},
+			ValidationWarning{"", "IT.riuso.codiceIPA", "This key is DEPRECATED and will be removed in the future. Use 'organisation.uri' and set it to 'urn:x-italian-pa:pcm' instead", 119, 5},
 		},
 	}
 
@@ -668,9 +674,9 @@ func TestDecodeValueErrorsRemote(t *testing.T) {
 		// Pinned to a commit: fetching from main means a testdata change
 		// breaks this test in every PR until the change itself lands.
 		{"https://raw.githubusercontent.com/italia/publiccode-parser-go/2a1f25a36e0f2ab2d71efb67db8b66ff00573fbe/testdata/v0/valid_with_warnings/valid_with_lowercase_countries.yml", ValidationResults{
-			ValidationWarning{"intendedAudience.countries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('IT')", 31, 7},
-			ValidationWarning{"intendedAudience.countries[1]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('DE')", 32, 7},
-			ValidationWarning{"intendedAudience.unsupportedCountries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('US')", 34, 7},
+			ValidationWarning{"", "intendedAudience.countries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('IT')", 31, 7},
+			ValidationWarning{"", "intendedAudience.countries[1]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('DE')", 32, 7},
+			ValidationWarning{"", "intendedAudience.unsupportedCountries[0]", "Lowercase country codes are DEPRECATED. Use uppercase instead ('US')", 34, 7},
 		}},
 	}
 
@@ -697,19 +703,19 @@ func TestRelativePathsOrURLs(t *testing.T) {
 		// Remote publiccode.yml and relative path in screenshots:
 		// should look for the screenshot remotely relative to this URL
 		{"https://raw.githubusercontent.com/italia/publiccode-parser-go/2a1f25a36e0f2ab2d71efb67db8b66ff00573fbe/testdata/v0/invalid/description_en_screenshots_missing_file.yml", ValidationResults{
-			ValidationError{"description.en.screenshots[0]", "'no_such_file.png' is not an image: HTTP GET failed for https://raw.githubusercontent.com/italia/publiccode-parser-go/2a1f25a36e0f2ab2d71efb67db8b66ff00573fbe/testdata/v0/invalid/no_such_file.png: not found", 42, 9},
+			ValidationError{"", "description.en.screenshots[0]", "'no_such_file.png' is not an image: HTTP GET failed for https://raw.githubusercontent.com/italia/publiccode-parser-go/2a1f25a36e0f2ab2d71efb67db8b66ff00573fbe/testdata/v0/invalid/no_such_file.png: not found", 42, 9},
 		}},
 
 		// Local publiccode.yml and relative path in screenshot:
 		// should look for the logo relative to this path in the filesystem
 		{"testdata/v0/invalid/description_en_screenshots_missing_file.yml", ValidationResults{
-			ValidationError{"description.en.screenshots[0]", "'no_such_file.png' is not an image: no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 42, 9},
+			ValidationError{"", "description.en.screenshots[0]", "'no_such_file.png' is not an image: no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 42, 9},
 		}},
 
 		// Remote publiccode.yml and URL in logo:
 		// should look for the logo remotely
 		{"https://raw.githubusercontent.com/italia/publiccode-parser-go/2a1f25a36e0f2ab2d71efb67db8b66ff00573fbe/testdata/v0/invalid/logo_missing_url.yml", ValidationResults{
-			ValidationError{"logo", "HTTP GET failed for https://google.com/no_such_file.png: not found", 18, 1},
+			ValidationError{"", "logo", "HTTP GET failed for https://google.com/no_such_file.png: not found", 18, 1},
 		}},
 
 		// Local publiccode.yml and URL in logo:
@@ -772,7 +778,7 @@ func TestRelativePathsOrURLsNoNetwork(t *testing.T) {
 		// should look for the logo relative to this path in the filesystem.
 		// DisableNetwork doesn't affect this so the check *IS* performed.
 		{"testdata/v0/invalid/description_en_screenshots_missing_file.yml", ValidationResults{
-			ValidationError{"description.en.screenshots[0]", "'no_such_file.png' is not an image: no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 42, 9},
+			ValidationError{"", "description.en.screenshots[0]", "'no_such_file.png' is not an image: no such file: " + cwd + "/testdata/v0/invalid/no_such_file.png", 42, 9},
 		}},
 	}
 
@@ -795,7 +801,7 @@ func TestRelativePathsOrURLsNoNetwork(t *testing.T) {
 func TestUrlMissingWithoutPath(t *testing.T) {
 	expected := map[string]error{
 		"url_missing.yml": ValidationResults{
-			ValidationError{"url", "url is a required field", 1, 1},
+			ValidationError{"", "url", "url is a required field", 1, 1},
 		},
 	}
 

--- a/v1_test.go
+++ b/v1_test.go
@@ -13,6 +13,7 @@ func TestInvalidTestcasesV1(t *testing.T) {
 
 	expected := ValidationResults{
 		ValidationError{
+			"",
 			"publiccodeYmlVersion",
 			"unsupported version: '1'. Supported versions: 0, 0.2, 0.2.0, 0.2.1, 0.2.2, 0.3, 0.3.0, 0.4, 0.4.0, 0.5.0, 0.5, 0.7.0, 0.7",
 			0,


### PR DESCRIPTION
Every diagnostic named the literal publiccode.yml, so an editor following the errorformat output opened the wrong file and a run over several files could not tell the results apart.