### PR TITLE
feat: set a descriptive User-Agent on the outgoing requests

### DIFF
--- a/internal/safehttp.go
+++ b/internal/safehttp.go
@@ -122,11 +122,39 @@ func (t *safeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
+// userAgentTransport sets a User-Agent on the requests that don't carry one.
+// Without it Go sends "Go-http-client/<version>", which WAFs and bot protections
+// routinely challenge: a perfectly reachable URL in a publiccode.yml then gets
+// reported as an error. Setting it here, at the transport level, covers every
+// caller of the client, whatever builds the request.
+type userAgentTransport struct {
+	base      http.RoundTripper
+	userAgent string
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// A caller that set its own User-Agent is left alone, and so is one that
+	// explicitly cleared it with an empty value. A nil Header is left alone as
+	// well: the base transport reports it as an error.
+	if _, set := req.Header["User-Agent"]; set || req.Header == nil {
+		return t.base.RoundTrip(req) //nolint:wrapcheck // http.Client inspects the transport error; keep it intact
+	}
+
+	// A RoundTripper must not modify the request it is given, hence the clone.
+	clone := req.Clone(req.Context())
+	clone.Header.Set("User-Agent", t.userAgent)
+
+	return t.base.RoundTrip(clone) //nolint:wrapcheck // http.Client inspects the transport error; keep it intact
+}
+
 // SafeHTTPClient builds an *http.Client hardened against SSRF and unbounded
 // downloads. When allowPrivate is true the SSRF address filtering is disabled
 // (used for trusted input and tests that target loopback servers); the response
 // size limit is always enforced.
-func SafeHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
+//
+// userAgent is sent as the User-Agent of every request that doesn't already
+// carry one. An empty userAgent leaves Go's default in place.
+func SafeHTTPClient(timeout time.Duration, allowPrivate bool, userAgent string) *http.Client {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
@@ -145,8 +173,13 @@ func SafeHTTPClient(timeout time.Duration, allowPrivate bool) *http.Client {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
+	var roundTripper http.RoundTripper = &safeTransport{base: transport, max: MaxResponseBytes}
+	if userAgent != "" {
+		roundTripper = &userAgentTransport{base: roundTripper, userAgent: userAgent}
+	}
+
 	return &http.Client{
 		Timeout:   timeout,
-		Transport: &safeTransport{base: transport, max: MaxResponseBytes},
+		Transport: roundTripper,
 	}
 }

--- a/internal/safehttp_test.go
+++ b/internal/safehttp_test.go
@@ -45,14 +45,14 @@ func TestSafeHTTPClientBlocksPrivate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	blocked := SafeHTTPClient(5*time.Second, false)
+	blocked := SafeHTTPClient(5*time.Second, false, "")
 	if _, err := blocked.Get(srv.URL); err == nil {
 		t.Fatal("expected the SSRF guard to block the loopback request")
 	} else if !errors.Is(err, ErrBlockedAddress) && !strings.Contains(err.Error(), "non-public") {
 		t.Errorf("expected a blocked-address error, got: %v", err)
 	}
 
-	allowed := SafeHTTPClient(5*time.Second, true)
+	allowed := SafeHTTPClient(5*time.Second, true, "")
 	resp, err := allowed.Get(srv.URL)
 	if err != nil {
 		t.Fatalf("expected the opt-out client to reach the server, got: %v", err)
@@ -133,4 +133,111 @@ func TestResponseUnderLimitIsReadFully(t *testing.T) {
 	if string(got) != body {
 		t.Errorf("body mismatch: got %q, want %q", got, body)
 	}
+}
+
+func TestUserAgentTransportSetsTheDefault(t *testing.T) {
+	const userAgent = "publiccode-parser-go/1.2.3 (+https://example.org)"
+
+	var got string
+	transport := &userAgentTransport{
+		base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			got = r.Header.Get("User-Agent")
+
+			return newResponse("", 0), nil
+		}),
+		userAgent: userAgent,
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != userAgent {
+		t.Errorf("User-Agent sent: got %q, want %q", got, userAgent)
+	}
+
+	// A RoundTripper must not modify the request it is handed.
+	if _, set := req.Header["User-Agent"]; set {
+		t.Errorf("the original request was modified: %q", req.Header.Get("User-Agent"))
+	}
+}
+
+func TestUserAgentTransportKeepsTheCallerHeader(t *testing.T) {
+	cases := map[string]string{
+		"caller sets its own": "harvester/2.0",
+		"caller clears it":    "",
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got string
+			var seen bool
+
+			transport := &userAgentTransport{
+				base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					got, seen = r.Header.Get("User-Agent"), true
+
+					return newResponse("", 0), nil
+				}),
+				userAgent: "publiccode-parser-go/1.2.3",
+			}
+
+			req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			req.Header["User-Agent"] = []string{want}
+
+			if _, err := transport.RoundTrip(req); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !seen {
+				t.Fatal("the base transport was not called")
+			}
+			if got != want {
+				t.Errorf("User-Agent sent: got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestSafeHTTPClientSendsUserAgent checks the User-Agent all the way down to the
+// wire, and that an empty one leaves Go's default alone.
+func TestSafeHTTPClientSendsUserAgent(t *testing.T) {
+	const userAgent = "publiccode-parser-go/1.2.3 (+https://example.org)"
+
+	// The server echoes back what it received, so there is nothing shared
+	// between the handler and the test.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.UserAgent())
+	}))
+	defer srv.Close()
+
+	got, err := getBody(SafeHTTPClient(5*time.Second, true, userAgent), srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != userAgent {
+		t.Errorf("User-Agent received by the server: got %q, want %q", got, userAgent)
+	}
+
+	if got, err = getBody(SafeHTTPClient(5*time.Second, true, ""), srv.URL); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(got, "Go-http-client/") {
+		t.Errorf("an empty User-Agent must leave Go's default in place, got %q", got)
+	}
+}
+
+// getBody GETs url and returns the response body as a string.
+func getBody(client *http.Client, url string) (string, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+
+	return string(body), err
 }

--- a/parser.go
+++ b/parser.go
@@ -76,6 +76,15 @@ type ParserConfig struct {
 	// Defaults to 30s if zero.
 	Timeout time.Duration
 
+	// UserAgent is sent in the User-Agent header of every request made during
+	// the external checks. It defaults to [UserAgent], which names this library
+	// and its version.
+	//
+	// Programs embedding the parser are encouraged to identify themselves here,
+	// so that the administrators of the sites being checked can tell their
+	// traffic apart and allow it.
+	UserAgent string
+
 	// AllowNetworkToPrivateHosts allows the external checks to connect to
 	// non-public addresses (loopback, private, link-local, ...).
 	//
@@ -119,10 +128,17 @@ func NewParser(config ParserConfig) (*Parser, error) {
 		timeout = defaultHTTPTimeout
 	}
 
+	userAgent := config.UserAgent
+	if userAgent == "" {
+		userAgent = UserAgent()
+	}
+
 	// Hardened HTTP client: refuses connections to non-public addresses (SSRF)
-	// and caps the size of each response (resource exhaustion). See
+	// and caps the size of each response (resource exhaustion). It also sets the
+	// User-Agent, which covers both the requests built here and the ones built
+	// by httpclient-lib-go, since they all go through this client. See
 	// internal/safehttp.go.
-	httpClient := urlutil.SafeHTTPClient(timeout, config.AllowNetworkToPrivateHosts)
+	httpClient := urlutil.SafeHTTPClient(timeout, config.AllowNetworkToPrivateHosts, userAgent)
 	vcsurl.Client = httpClient
 	p := Parser{
 		disableNetwork:        config.DisableNetwork,

--- a/publiccode-parser/publiccode_parser.go
+++ b/publiccode-parser/publiccode_parser.go
@@ -93,6 +93,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 	config.DisableExternalChecks = *disableExternalChecksPtr
 	config.Timeout = *timeoutPtr
 
+	// The version is stamped in at link time, so it's more reliable here than
+	// the build information the library falls back to.
+	config.UserAgent = publiccode.UserAgentForVersion(version)
+
 	p, err := publiccode.NewParser(config)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error creating Parser: %s\n", err.Error())

--- a/useragent.go
+++ b/useragent.go
@@ -1,0 +1,107 @@
+package publiccode
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
+
+const (
+	// productName is the token identifying this software in the User-Agent.
+	productName = "publiccode-parser-go"
+
+	// projectURL is part of the User-Agent so that whoever finds these requests
+	// in their logs can tell what made them, and allow them explicitly instead
+	// of having to allow every Go program.
+	projectURL = "https://github.com/italia/publiccode-parser-go"
+
+	// modulePath is this module's import path. The version is looked up under it
+	// in the build information: the parser is the main module when its own CLI
+	// runs, and a dependency when the library is embedded in another program.
+	modulePath = "github.com/italia/publiccode-parser-go/v5"
+
+	// unknownVersion stands in when the build information carries no usable
+	// version, as happens with "go run", "go test" and unstamped builds.
+	unknownVersion = "devel"
+)
+
+// userAgent is resolved once: the build information doesn't change at runtime.
+var userAgent = buildUserAgent(buildInfo())
+
+// UserAgent returns the value the parser sends in the User-Agent header of the
+// requests it makes during the external checks, e.g.
+//
+//	publiccode-parser-go/5.4.3 (+https://github.com/italia/publiccode-parser-go)
+//
+// The version comes from the build information of the running binary, and is
+// "devel" when there is none to be found.
+//
+// Programs embedding the parser should identify themselves instead, through
+// [ParserConfig.UserAgent]. This function is exported for the ones that want to
+// keep this token and add their own to it.
+func UserAgent() string {
+	return userAgent
+}
+
+// UserAgentForVersion returns the same User-Agent as [UserAgent], for the
+// version passed instead of the one in the build information.
+//
+// It exists for binaries that have their version stamped in at link time, as
+// the publiccode-parser CLI does: they know it, while the build information of
+// a binary built from a list of files carries no module version at all.
+func UserAgentForVersion(version string) string {
+	return fmt.Sprintf("%s/%s (+%s)", productName, normalizeVersion(version), projectURL)
+}
+
+// buildInfo returns the build information of the running binary, or nil when it
+// is unavailable.
+func buildInfo() *debug.BuildInfo {
+	info, _ := debug.ReadBuildInfo()
+
+	return info
+}
+
+// buildUserAgent formats the User-Agent for the version of this module recorded
+// in info.
+func buildUserAgent(info *debug.BuildInfo) string {
+	return UserAgentForVersion(moduleVersion(info))
+}
+
+// moduleVersion digs the version of this module out of info. It answers an empty
+// string when info records none, which is the case for a binary built from a
+// list of files (as the released CLI is) and when info itself is nil.
+func moduleVersion(info *debug.BuildInfo) string {
+	if info == nil {
+		return ""
+	}
+
+	// The main module is this one when one of its own commands runs: its path is
+	// the module path for the module itself, and below it for a command.
+	if info.Main.Path == modulePath || strings.HasPrefix(info.Main.Path, modulePath+"/") {
+		return info.Main.Version
+	}
+
+	// The parser is a dependency when the library is embedded in another program.
+	for _, dep := range info.Deps {
+		if dep != nil && dep.Path == modulePath {
+			return dep.Version
+		}
+	}
+
+	return ""
+}
+
+// normalizeVersion turns a Go module version into what goes in the User-Agent:
+// a bare version without the "v" prefix, or unknownVersion when there is
+// nothing usable. A pseudo-version is kept as it is, since it identifies the
+// commit.
+func normalizeVersion(version string) string {
+	version = strings.TrimPrefix(version, "v")
+
+	// An unstamped main module reports "(devel)".
+	if version == "" || strings.HasPrefix(version, "(") {
+		return unknownVersion
+	}
+
+	return version
+}

--- a/useragent_test.go
+++ b/useragent_test.go
@@ -1,0 +1,192 @@
+package publiccode
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestBuildUserAgent(t *testing.T) {
+	cases := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "no build information",
+			info: nil,
+			want: "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "released CLI: this module is the main one",
+			info: &debug.BuildInfo{Main: debug.Module{Path: modulePath, Version: "v5.4.3"}},
+			want: "publiccode-parser-go/5.4.3 (+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "unstamped build of the CLI",
+			info: &debug.BuildInfo{Main: debug.Module{Path: modulePath, Version: "(devel)"}},
+			want: "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "embedded as a library: this module is a dependency",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.org/harvester", Version: "v1.0.0"},
+				Deps: []*debug.Module{
+					{Path: "example.org/other", Version: "v0.1.0"},
+					{Path: modulePath, Version: "v5.4.3"},
+				},
+			},
+			want: "publiccode-parser-go/5.4.3 (+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "pseudo-version identifies the commit and is kept",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "example.org/harvester", Version: "v1.0.0"},
+				Deps: []*debug.Module{{Path: modulePath, Version: "v5.4.4-0.20260316100201-5dd490bc4896"}},
+			},
+			want: "publiccode-parser-go/5.4.4-0.20260316100201-5dd490bc4896 " +
+				"(+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "CLI installed with \"go install\": the main module is the command",
+			info: &debug.BuildInfo{Main: debug.Module{Path: modulePath + "/publiccode-parser", Version: "v5.4.3"}},
+			want: "publiccode-parser-go/5.4.3 (+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "release build of the CLI: no module version in the build information",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "command-line-arguments"}},
+			want: "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+		},
+		{
+			name: "this module is nowhere to be found",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.org/harvester", Version: "v1.0.0"}},
+			want: "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildUserAgent(tc.info); got != tc.want {
+				t.Errorf("buildUserAgent() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUserAgentForVersion(t *testing.T) {
+	cases := map[string]string{
+		"5.4.3":   "publiccode-parser-go/5.4.3 (+https://github.com/italia/publiccode-parser-go)",
+		"v5.4.3":  "publiccode-parser-go/5.4.3 (+https://github.com/italia/publiccode-parser-go)",
+		"devel":   "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+		"(devel)": "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+		"":        "publiccode-parser-go/devel (+https://github.com/italia/publiccode-parser-go)",
+	}
+
+	for version, want := range cases {
+		if got := UserAgentForVersion(version); got != want {
+			t.Errorf("UserAgentForVersion(%q) = %q, want %q", version, got, want)
+		}
+	}
+}
+
+func TestUserAgentNamesThisProject(t *testing.T) {
+	got := UserAgent()
+
+	if !strings.HasPrefix(got, productName+"/") {
+		t.Errorf("UserAgent() = %q, want it to start with %q", got, productName+"/")
+	}
+	if !strings.Contains(got, projectURL) {
+		t.Errorf("UserAgent() = %q, want it to point at %q", got, projectURL)
+	}
+}
+
+// userAgentRecorder is a server recording the User-Agent of every request it
+// receives.
+type userAgentRecorder struct {
+	*httptest.Server
+
+	mu   sync.Mutex
+	seen []string
+}
+
+// newUserAgentRecorder starts a recording server, stopped when the test ends.
+func newUserAgentRecorder(t *testing.T) *userAgentRecorder {
+	t.Helper()
+
+	recorder := &userAgentRecorder{}
+	recorder.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		recorder.mu.Lock()
+		recorder.seen = append(recorder.seen, r.UserAgent())
+		recorder.mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/yaml")
+		_, _ = w.Write([]byte("publiccodeYmlVersion: \"0.4\"\n"))
+	}))
+
+	t.Cleanup(recorder.Close)
+
+	return recorder
+}
+
+// userAgents returns the User-Agents recorded so far.
+func (r *userAgentRecorder) userAgents() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.seen)
+}
+
+// TestUserAgentIsSentOnEveryRequestPath covers the two ways the parser reaches
+// the network: the request it builds itself in Parse(), and the ones built by
+// httpclient-lib-go during the external checks.
+func TestUserAgentIsSentOnEveryRequestPath(t *testing.T) {
+	cases := map[string]string{
+		"default":  UserAgent(),
+		"override": "harvester/2.0 (+https://example.org)",
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := newUserAgentRecorder(t)
+
+			config := ParserConfig{AllowNetworkToPrivateHosts: true}
+			if name == "override" {
+				config.UserAgent = want
+			}
+
+			p, err := NewParser(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Parse() builds its request itself.
+			_, _ = p.Parse(srv.URL + "/publiccode.yml")
+
+			// The external checks go through httpclient-lib-go.
+			u, err := url.Parse(srv.URL + "/anything")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err = p.isReachable(*u); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			seen := srv.userAgents()
+			if len(seen) < 2 {
+				t.Fatalf("expected both request paths to reach the server, got %d request(s)", len(seen))
+			}
+
+			for _, got := range seen {
+				if got != want {
+					t.Errorf("User-Agent received by the server: got %q, want %q", got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #421.

## What it does

Sends `publiccode-parser-go/<version> (+https://github.com/italia/publiccode-parser-go)` as the `User-Agent` of every request the external checks make, instead of Go's default `Go-http-client/<version>`.

## How

The header is set in the transport built by `internal.SafeHTTPClient`, not at the call sites. You noted that requests go out both through `httpclient-lib-go` and directly in `parser.go`; both use the `*http.Client` that function returns (and so does `go-vcsurl`, through `vcsurl.Client`), so setting it one layer down covers all three paths and any future call site. The `RoundTripper` only fills the header in when the request doesn't already carry one, and it clones the request rather than mutating the caller's.

`ParserConfig.UserAgent` overrides the default, for harvesters embedding the library.

## The version in the string

It comes from `debug.ReadBuildInfo()`: `Main.Version` when one of this module's own commands is running, otherwise the recorded version of this module as a dependency. It falls back to `devel`.

One wrinkle worth your attention: `.goreleaser.yml` builds `main: ./publiccode-parser/publiccode_parser.go`, a **file list**, and such a binary embeds no module version at all (`go version -m` shows `path command-line-arguments` and no `mod` line). So the released CLI would report `devel`. Since it already has its version stamped in at link time, it now passes it explicitly via `publiccode.UserAgentForVersion(version)`. That's the reason for the second exported function — happy to drop it and instead build the CLI from its package (`./publiccode-parser`) if you'd rather have the smaller API surface; that would make the build information carry the version, but it changes the release build and the reproducibility check.

## Tests

- `internal/safehttp_test.go`: the header is set when absent, a caller's own value (or an explicitly empty one) is left alone, the original request isn't mutated, and the value arrives on the wire.
- `useragent_test.go`: the version resolution for each build shape (released CLI, `go install`, embedded as a library, pseudo-version, no build info), plus an end-to-end check that both request paths — `Parse()` and the `httpclient-lib-go` external checks — send it, with and without the `ParserConfig` override.

`go test -race ./...` passes; `golangci-lint run` reports nothing new on the changed files.

## What I could not verify

The Cloudflare 403 from the issue no longer reproduces: `https://www.xwiki.org/` answers 200 to `Go-http-client/2.0` today, so I couldn't confirm on that host that the new string gets through. The change is verified at the header level, not against a live WAF.

---

**Please review this carefully.** I don't know Go and I don't know this codebase — the investigation in #421 and the code in this PR were produced with [Claude Code](https://claude.com/claude-code), and I'm not in a position to vouch for the idiomatic quality or for details I might have missed. I hope it's useful as a starting point; rewrite whatever needs rewriting.
